### PR TITLE
Consistency Update pass on Standards

### DIFF
--- a/SplashDamageCodingStandard.h
+++ b/SplashDamageCodingStandard.h
@@ -49,15 +49,15 @@
 #include "GameFramework/HUDHitBox.h"
 
 // [header.rule.path]
-// Use the shortest possible path for including files. Not doing so hides missing dependencies
-// between modules and can cause hard to track linker or compiler errors at a later date.
-//  - if the header is in a Public subfolder, you can just use the filename (e.g. "CoreMinimal.h").
-//  - if the header is in a Classes subfolder, you can use the relative path from Classes. (e.g. "GameFramework/Pawn.h")
+// 	Use the shortest possible path for including files. Not doing so hides missing dependencies
+// 	between modules and can cause hard to track linker or compiler errors at a later date.
+//  	- if the header is in a Public subfolder, you can just use the filename (e.g. "CoreMinimal.h").
+//  	- if the header is in a Classes subfolder, you can use the relative path from Classes. (e.g. "GameFramework/Pawn.h")
 
 // [header.rule.privatepath]
-// Never include private paths in a public header file. This can cause hard to track linker
-// or compiler errors at a later date. Either re-factor your code so that you can use a forward
-// declare or, if necessary, make the file you are trying to include public.
+// 	Never include private paths in a public header file. This can cause hard to track linker
+// 	or compiler errors at a later date. Either re-factor your code so that you can use a forward
+// 	declare or, if necessary, make the file you are trying to include public.
 
 // [header.rule.gen] always have the .generated files last
 #include "SplashDamageCodingStandard.generated.h"
@@ -76,12 +76,12 @@ class ASDCodingStandardExampleActor : public ACharacter
 	GENERATED_BODY() // GENERATED_UCLASS_BODY is deprecated
 
 	// [ue.gen.access] follow up the reflection macros with access level specifiers 
-	// because they don't modify them anymore (used to be the case)
-	// structs do not need to specify public, unless they also specify protected/private (see [ue.gen.struct])
+	// 	because they don't modify them anymore (used to be the case)
+	// 	structs do not need to specify public, unless they also specify protected/private (see [ue.gen.struct])
 public:
 
 	// [class.ctor.default] don't write an empty one, remove it
-	// due to the way GENERATED_BODY works, `= default`-ing the constructor can lead to crashes
+	// 	due to the way GENERATED_BODY works, `= default`-ing the constructor can lead to crashes
 
 	// [class.dtor] don't write empty one, default or remove it
 	//	respect the rule of 3/5/0 http://en.cppreference.com/w/cpp/language/rule_of_three
@@ -89,8 +89,8 @@ public:
 
 	// [class.virtual] explicitly mark up virtual methods
 	//	- always use the `override` specifier
-	//  - use the `final` specifier sparingly and with care as it can have large ramifications on downstream classes.
-	//  - group overridden functions by the class that first defined, them using begin/end comments (as below)
+	//  	- use the `final` specifier sparingly and with care as it can have large ramifications on downstream classes.
+	//  	- group overridden functions by the class that first defined, them using begin/end comments (as below)
 
 	// Begin AActor override
 	virtual void BeginPlay() override;
@@ -105,37 +105,34 @@ public:
 	// [comment.useless] DON'T write meaningless comments!
 	//	they should always reflect bigger purpose or reveal hidden details
 	/** Returns Mesh subobject **/
-	/* BAD -> */ FORCEINLINE USkeletalMeshComponent* GetMesh() const { return MyMesh; } /* <- BAD */
+	/* BAD -> */ FORCEINLINE const USkeletalMeshComponent* GetMesh() const { return MyMesh; } /* <- BAD */
 
 	// [class.inline.good] Move the definitions of inline function outside the class
-	TWeakObjectPtr<USkeletalMeshComponent> GoodExampleOfInline();
+	const USkeletalMeshComponent* GoodExampleOfInline() const;
 
 protected:
 	// [class.order] Do not alternate between functions and variables in the class declaration
-	// Put all functions first, all variables last
+	// 	Put all functions first, all variables last
 
 	// [ue.ecs.split] Split functionality into components
 	//	avoid creating monolithic giant classes!
-	// [header.rule.fwd] example of in-place forward declaration
 
 	// [ue.ecs.gc] never use naked pointers to UObject's, always have UPROPERTY or UE smart ptr
 	//	Generally, for storing pointers to classes you don't own, use TWeakObjectPtr.
-	//	Don't initialise TWeakObjectPtr as it will force you to include the header file for the container class.
-	TWeakObjectPtr<USkeletalMeshComponent> OtherMesh; /* <- GOOD */
-	//TWeakObjectPtr<USkeletalMeshComponent> AnotherMesh = nullptr; /* <- BAD and not compiling */
+	TWeakObjectPtr<const USkeletalMeshComponent> OtherMesh = nullptr;
 	//	Generally, for storing pointers to classes you do own, use UPROPERTY() and initialise.
 	UPROPERTY(BlueprintReadOnly, Category = Mesh)
-	USkeletalMeshComponent* MyMesh = nullptr;
+		const USkeletalMeshComponent* MyMesh = nullptr;
 	//	For more information on other forms of UE4 smart pointers see
 	//	https://docs.unrealengine.com/latest/INT/Programming/UnrealArchitecture/SmartPointerLibrary/ 
 
 	// [class.order.replication] As an exception to [class.ordering], declare replication functions
-	// next to the variable that used them to avoid cluttering the interface with these functions that
-	// are not called by client code.
+	// 	next to the variable that used them to avoid cluttering the interface with these functions that
+	// 	are not called by client code.
 	UPROPERTY(Transient, ReplicatedUsing = "OnRep_WantsToSprint")
-	bool WantsToSprint = false;
+		bool WantsToSprint = false;
 	UFUNCTION()
-	void OnRep_WantsToSprint();
+		void OnRep_WantsToSprint();
 };
 
 // [ue.gen.struct] [ue.ecs.group] move groups of Blueprint exposed variables into separate structures
@@ -161,16 +158,16 @@ struct FSDCodingStandardBlueprintVarGroup
 	float CameraTraceVolumeWidth = 96.0f * 5;
 
 	// [class.member.config] member variables that are used as editor config variables
-	//  MUST have a comment supplied as it shows up as the tooltip in the Editor.
-	//  They should also be marked as EditDefaultsOnly by default.
-	//  If you expect them to be read in blueprints then use BlueprintReadOnly.
-	//  Only use EditAnywhere, EditInstanceOnly or BlueprintReadWrite if it's necessary for your use case.
+	//  	MUST have a comment supplied as it shows up as the tooltip in the Editor.
+	//  	They should also be marked as EditDefaultsOnly by default.
+	//  	If you expect them to be read in blueprints then use BlueprintReadOnly.
+	//  	Only use EditAnywhere, EditInstanceOnly or BlueprintReadWrite if it's necessary for your use case.
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
 	float CameraTraceVolumeHeight = 96.0f * 5;
 
 	// [hardware.cache] try to order data members with cache and alignment in mind
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-	bool ShowCameraWidget = true; 
+	bool ShowCameraWidget = true;
 
 	// [hardware.cache] for ex grouping similar types like this will minimize the 
 	//	internal padding the compiler will add
@@ -181,7 +178,7 @@ struct FSDCodingStandardBlueprintVarGroup
 
 // [cpp.enum.strong] use the strongly typed enums rather than old C style + dirty namespace tricks
 // [cpp.enum.generated] Use the GenerateStringFuncs parameter if you need string conversion or
-// query the number of values. Don't write boilerplate code for this yourself
+// 	query the number of values. Don't write boilerplate code for this yourself
 UENUM(GenerateStringFuncs)
 enum class ESDCodingStandardEnum // `: uint8` optional underlying type 
 {
@@ -201,18 +198,16 @@ class USDCodingStandardExampleComponent : public USceneComponent
 
 public:
 	// [func.arg.readability] avoid `bool` function arguments, especially successions of them	
-	/* BAD -> */ void FuncHardToReadOnCall(int Order, bool bSetCache, bool bUseLog); /* <- BAD */
-	using TOrder = int;
+	/* BAD -> */ void FuncHardToReadOnCall(bool bSetCache, bool bUseLog); /* <- BAD */
 	enum class ECacheFlags { Use, Disabled, Unspecified };
 	enum class ELogging { Yes, No };
-	/* GOOD -> */ void FuncNiceToReadOnCall(TOrder, ECacheFlags, ELogging);
+	/* GOOD -> */ void FuncNiceToReadOnCall(ECacheFlags, ELogging); /* <- GOOD */
 	//	argument names in declarations are ignored, try to encode as much meaning as possible in the type
-	//	also even this simple typedef/using goes a long way readability wise at the call site:
-	//	ex: FuncNiceToReadOnCall(FOrder(42), FCacheFlags::Use, FLogFlags::Custom, FLoadOnPlay(false));
+	//	ex: FuncNiceToReadOnCall(FCacheFlags::Use, FLogFlags::Custom, FLoadOnPlay(false));
 
 	// [func.arg.readability] avoid consecutive chains of same type, avoid too many arguments
-	/* BAD -> */ void FuncWithTooManyArgs(FVector Location, FVector Origin, FVector EndPoint,
-		FRotator Rotation, UPrimitiveComponent *Parent, AActor *Owner, float Damage, float Radius); /* <- BAD */
+	/* BAD -> */ void FuncWithTooManyArgs(const FVector& Location, const FVector& Origin, const FVector& EndPoint,
+		const FRotator& Rotation, const UPrimitiveComponent& Parent, const AActor& Owner, float Radius); /* <- BAD */
 	// try to add a helper structure, or maybe you can split in more functions that are less complex each
 
 	// [singleton.no] NEVER USE SINGLETONS!!!
@@ -220,28 +215,27 @@ public:
 	//	- they interfere/break with Hot Reload and plugins
 	//	- discuss alternatives with your lead
 	//	- if you somehow have to add one, first reconsider, then use the Meyers pattern: https://stackoverflow.com/a/1661564
-	/* BAD -> */ static USDCodingStandardExampleComponent* Instance; // defined in .cpp
-	/* VERY BAD -> */ USDCodingStandardExampleComponent* GetInstance() { return Instance; }
+	/* BAD -> */ static USDCodingStandardExampleComponent& Instance; // defined in .cpp
+	/* VERY BAD -> */ USDCodingStandardExampleComponent& GetInstance() { return Instance; }
 
 	// [ue.alloc] expose the allocation as a policy for new utility methods you write
 	//	this way the caller has a chance to decide how memory is utilized
 	template<class AllocatorType>
-	void GetComponents(TArray<UActorComponent *, AllocatorType>& OutComponents);
+	void GetComponents(TArray<const UActorComponent&, AllocatorType>& OutComponents) const;
 
 	// [cpp.lambda] used later for guidelines
-	void LambdaStyle(AActor *ExternalEntity);
+	void LambdaStyle(const AActor* ExternalEntity);
 
-	// [cpp.rel_ops] when implementing relation operators, use the binary free form
-	//	as it provides the most flexibility with operands order and usage
+	// [cpp.rel_ops] when implementing relation operators, for consistency sake, use the binary free form
 	//	if it needs to access private members, make it `friend` and respect [class.inline.good]
 	// NOTE: add working functionality only for `==` and `<` everything else can be inferred from them
 	friend inline bool operator == (
-		const USDCodingStandardExampleComponent &lhs,
-		const USDCodingStandardExampleComponent &rhs);
+		const USDCodingStandardExampleComponent& lhs,
+		const USDCodingStandardExampleComponent& rhs);
 
 protected:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
-	FSDCodingStandardBlueprintVarGroup BlueprintGroup;
+		FSDCodingStandardBlueprintVarGroup BlueprintGroup;
 
 private:
 	// [class.constant] best way to define constants
@@ -255,36 +249,31 @@ private:
 	//	DON'T add `b` prefix to bool declaration names!
 	//	instead use English Modal Verbs and variations like: Can, Does, Will, Is, Has, Use, etc
 	bool bInGame, bAttack, bLog, bCustomStencil; /* <- BAD */
-	bool InGame, CanAttack, UseLog, HasCustomStencil; /* <- GOOD */
+	bool IsInGame, CanAttack, UseLog, HasCustomStencil; /* <- GOOD */
 };
 
 // [class.inline.good]
-//	- don't use FORCEINLINE unless you really want to persuade the
-//		compiler to inline a complicated function
-//		which is NOT guaranteed to work!
-//	- 100% for one-liners or very simple functions inline-ing will work regardless
 //	- here we have to use the `inline` to allow proper linkage
-//		this simple function would have been inlined anyway
+//		for one-liners or very simple functions inline-ing will work regardless
 //	- having it like this also helps refactoring
 //		you can easily move this to the .cpp without messing up the class definition
-inline TWeakObjectPtr<USkeletalMeshComponent> ASDCodingStandardExampleActor::GoodExampleOfInline()
+inline const USkeletalMeshComponent* ASDCodingStandardExampleActor::GoodExampleOfInline() const
 {
-	return OtherMesh;
+	return OtherMesh.Get();
 }
 
-// [cpp.rel_ops] when implementing relation operators, use the binary free form
-//	as it provides the most flexibility with operands order and usage
+// [cpp.rel_ops] when implementing relation operators, for consistency sake, use the binary free form
 //	if it needs to access private members, make it `friend` and respect [class.inline.good]
 // NOTE: add working functionality only for `==` and `<` everything else can be inferred from them
 inline bool operator == (
-	const USDCodingStandardExampleComponent &lhs,
-	const USDCodingStandardExampleComponent &rhs)
+	const USDCodingStandardExampleComponent& lhs,
+	const USDCodingStandardExampleComponent& rhs)
 {
-	return lhs.InGame == rhs.InGame;
+	return lhs.IsInGame == rhs.IsInGame;
 }
 
 // [cpp.namepace.public] Use a namespace to contain free functions.
-// This helps manage potential name clashes and unity build issues.
+// 	This helps manage potential name clashes and unity build issues.
 namespace SDCodingStandardHelpers
 {
 	void PublicHelper(const USDCodingStandardExampleComponent& Object);
@@ -308,10 +297,10 @@ namespace SDCodingStandardHelpers
 //	- Classes, Struct & Enums in Game modules should be prefixed with SD
 
 // [module.naming.namespace]
-// - Namespaces in Core modules should be prefixed with SDC
-// - Namespaces in Game modules should be prefixed with SD
-// - Namespaces should be named the same as the file they live in
-// - Namespaces may be postfixed with "Helpers" where it prevents ambiguity
+// 	- Namespaces in Core modules should be prefixed with SDC
+// 	- Namespaces in Game modules should be prefixed with SD
+// 	- Namespaces should be named the same as the file they live in
+// 	- Namespaces may be postfixed with "Helpers" where it prevents ambiguity
 
 // [module.dependency] modules should follow strict dependency rules
 //	- Interface modules should only include engine modules.


### PR DESCRIPTION
Made comment style consistent across document.
Made const use more prevalent across document
Made style of using * and & more consistent across document and made & more prevalent.
Don't return TWeakObjectPtr from Get function. It serves no purpose and makes things more complicated for the caller.
Reworded comment about implementing relation operators to make it more about consistency, rather then flexibility.