### PR TITLE
 Style Improvements

### DIFF
--- a/SplashDamageCodingStandard.cpp
+++ b/SplashDamageCodingStandard.cpp
@@ -324,7 +324,7 @@ void ASDCodingStandardExampleActor::OnRep_WantsToSprint()
 {
 }
 
-void USDCodingStandardExampleComponent::LambdaStyle(const AActor& ExternalEntity) const
+void USDCodingStandardExampleComponent::LambdaStyle(const AActor* ExternalEntity) const
 {
 	// [cpp.lambda.general] use lambda's to your advantage
 	//  especially when they will isolate work in the implementation

--- a/SplashDamageCodingStandard.cpp
+++ b/SplashDamageCodingStandard.cpp
@@ -35,22 +35,22 @@
 // 	SPLASH_DAMAGE_CHANGE engine guards around modifications in the file (see [markup.engine])
 
 // [basic.layout] try to limit horizontal space and use vertical layout
-//	there is a reason newspapers have columns ;)
-//	80 characters is a good guideline to strive for
+//  there is a reason newspapers have columns ;)
+//  80 characters is a good guideline to strive for
 // --------------------------------------------- 80 char limit --------------->|
 // --------------------------------------------- 100 char limit ---------------------------------->|
-//  	you can add an indicator with visual assist: 
-//  	Visual Assist Options -> Display -> Display indicator after column n
+//  you can add an indicator with visual assist: 
+//  Visual Assist Options -> Display -> Display indicator after column n
 
 // [comment.type]
-//	always use the C++ style and not the C /**/ style
-//	because it shows up in searches
-//	Visual Studio shortcut to toggle comments on a block:
-//		Edit -> Advanced -> Un/Comment Selection
-//		Ctrl+K Ctrl+C / Ctrl+K Ctrl+U
+//  always use the C++ style and not the C /**/ style
+//  because it shows up in searches
+//  Visual Studio shortcut to toggle comments on a block:
+//      Edit -> Advanced -> Un/Comment Selection
+//      Ctrl+K Ctrl+C / Ctrl+K Ctrl+U
 
 // [header.incl.order.cpp]
-// Generally speaking the include order of files in .cpp's should be
+//  Generally speaking the include order of files in .cpp's should be
 #include "SplashDamageCodingStandard.h"			// 1) the equivalent header file
 
 #include <Components/PrimitiveComponent.h>		// 2) Engine files
@@ -64,7 +64,7 @@
 //#include "ViewModel.h"						// 5) Local files
 
 // [cpp.namespace.private] use a namespace to wrap translation-unit local free functions 
-// 	defined only in cpp files. Also mark them as static to enforce internal only linkage.
+//  defined only in cpp files. Also mark them as static to enforce internal only linkage.
 namespace SDCodingStandardHelpers
 {
 	static void PrivateHelper(const USDCodingStandardExampleComponent& Object)
@@ -73,13 +73,13 @@ namespace SDCodingStandardHelpers
 }
 
 // [basic.order] respect the order of declarations in the .h header
-//	when you write the definitions here
+//  when you write the definitions here
 
 // [basic.rule.brace] FOLLOW UE4 coding style i.e. Allman style aka one every line
 void BraceStyle()
 {
 	// illustration purpose only - don't do this in live code (use bit sets instead of many bool's)
-	bool FailCondition = false, TrueCondition = true,
+	const bool FailCondition = false, TrueCondition = true,
 		SomethingElse = true, Contract = true, Binding = true;
 
 	if (FailCondition)
@@ -109,8 +109,8 @@ void BraceStyle()
 	}
 	
 	// [cpp.return.early] use early returns to avoid excessive nesting
-	//	especially for pre-conditions / contracts
-	//	one exception is logic flow where too many early returns would hurt readability
+	//  especially for pre-conditions / contracts
+	//  one exception is logic flow where too many early returns would hurt readability
 	if (!Contract && !Binding)
 	{
 		return;
@@ -124,15 +124,15 @@ void BraceStyle()
 	}
 
 	// [cpp.if.init] use the if-with-initializer idiom
-	if (bool IsGame = FApp::IsGame())
+	if (const bool IsGame = FApp::IsGame())
 	{
 		// ...
 	}
 }
 
 // [globals.no] avoid globals unless they're POD (plain-old-data)
-//	they don't play well with Hot Reload and their order of initialization
-//	is undefined. Epic loves them but we don't!
+//  they don't play well with Hot Reload and their order of initialization
+//  is undefined. Epic loves them but we don't!
 FIntPoint CachedCoordinates; // PASSABLE
 class MyBigObject
 {
@@ -142,35 +142,35 @@ MyBigObject Cache1; // BAD
 MyBigObject Cache2; // BAD - maybe this is started first, not Cache1
 
 // [cpp.return] consider using TOptional for returns that can fail
-//	instead of using C style pass by reference
-TOptional<FIntRect> IntersectTest(const FIntPoint &min, const FIntPoint &max)
+//  instead of using C style pass by reference
+TOptional<FIntRect> IntersectTest(const FIntPoint& min, const FIntPoint& max)
 {
 	// ...
 	return (min.X > max.X || min.Y > max.Y) ? TOptional<FIntRect>() : FIntRect(min, max);
 }
 
 // [ue.gen.struct] if Blueprint variables are extracted in separate structures
-//	it is possible to pass them around, thus not having to expose all functions as
-//	methods in a class, thus leading to less coupling and faster compilation
-float DoPassBlueprintVarStructs(const FSDCodingStandardBlueprintVarGroup &vars)
+//  it is possible to pass them around, thus not having to expose all functions as
+//  methods in a class, thus leading to less coupling and faster compilation
+float DoPassBlueprintVarStructs(const FSDCodingStandardBlueprintVarGroup& vars)
 {
 	return vars.CameraTraceVolumeWidth / 2.f;
 }
 
-void DontWasteMemory(AActor *Actor)
+void DontWasteMemory(const AActor& Actor)
 {
 	// [ue.container] Mind your allocations!
-	//	don't go to the heap, go to the stack!
+	//  don't go to the heap, go to the stack!
 	TInlineComponentArray<UPrimitiveComponent*> PrimComponents; // 24 item reserved by default
-	Actor->GetComponents(PrimComponents);
+	Actor.GetComponents(PrimComponents);
 	
 	// [ue.container] [ue.ecs.get] Customize the get-ers for this purpose!
 	using TCustomAlloc = TInlineAllocator<32>;
 	TArray<UActorComponent *, TCustomAlloc> LocalItems;
-	Actor->GetComponents<UActorComponent, TCustomAlloc>(LocalItems);
+	Actor.GetComponents<UActorComponent, TCustomAlloc>(LocalItems);
 	
 	// [ue.container.reserve] Prepare upfront the containers
-	//	cut down on the need to allocate per-item
+	//  cut down on the need to allocate per-item
 	PrimComponents.Reserve(64);
 	PrimComponents.Init(nullptr, 64);
 	
@@ -181,32 +181,32 @@ void DontWasteMemory(AActor *Actor)
 
 	// [hardware.cache] be mindful of cache access and plan your memory access accordingly
 	//
-	//	1 CPU cycle
-	//	o
+	//  1 CPU cycle
+	//  o
 	//
-	//	L1 cache access
-	//	ooo
+	//  L1 cache access
+	//  ooo
 	//
-	//	L2 cache access
-	//	ooooooooo
+	//  L2 cache access
+	//  ooooooooo
 	//
-	//	L3 cache access
-	//	oooooooooooooooooooooooooooooooooooooooooo
+	//  L3 cache access
+	//  oooooooooooooooooooooooooooooooooooooooooo
 	//
-	//	Main memory access
-	//	ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-	//	ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-	//	ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-	//	ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+	//  Main memory access
+	//  ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+	//  ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+	//  ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+	//  ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 	//
-	//	from https://twitter.com/srigi/status/917998817051541504
+	//  from https://twitter.com/srigi/status/917998817051541504
 	//
-	//	Some general tips
-	//	- prefer linear data structures, don't jump via pointers too much etc
-	//	- all cache access is through lines 64 bytes long, have that in mind!
-	//	- in classes put related data together, group them by algorithm/logic access
-	//	- be mindful of the invisible packing the compiler will do behind your back
-	//		don't intermingle bool's or small types willy nilly with bigger ones etc
+	//  Some general tips
+	//  - prefer linear data structures, don't jump via pointers too much etc
+	//  - all cache access is through lines 64 bytes long, have that in mind!
+	//  - in classes put related data together, group them by algorithm/logic access
+	//  - be mindful of the invisible packing the compiler will do behind your back
+	//      don't intermingle bool's or small types willy nilly with bigger ones etc
 }
 
 // [markup.engine] Use special markers for engine changes
@@ -225,7 +225,7 @@ void EngineChanges()
 	//	 i.e. commenting out the section vs actually removing it
 }
 
-void GameWithEditorChanges(TArray<int> Widgets)
+void GameWithEditorChanges(const TArray<int>& Widgets)
 {
 // [markup.editor] isolate Editor specific changes in game code
 #if WITH_EDITOR
@@ -238,8 +238,8 @@ void GameWithEditorChanges(TArray<int> Widgets)
 }
 
 // [cpp.auto] use `auto` or not at your discretion but BE CONSISTENT
-//	- if a part of code already has an auto style, follow it, don't mix
-//	- don't bikeshed over the merits of each style, pick one and stick with it
+//  - if a part of code already has an auto style, follow it, don't mix
+//  - don't bikeshed over the merits of each style, pick one and stick with it
 void AutoStyle()
 {
 	// [cpp.auto.init] auto forces to have initialization - this is always good
@@ -258,7 +258,7 @@ void AutoStyle()
 	auto still_bad = static_cast<const int>(Int); // <- BAD: type is still `int`
 
 	// [cpp.auto.golden-rule] ALWAYS mark auto with the appropriate qualifiers:
-	//	const, &, * - even if it's superfluous
+	//  const, &, * - even if it's superfluous
 	auto &proper_ref = Int;
 	auto &enforce_ref = RefInt;
 	auto hidden_ptr = &Int; // <- BAD even if it still works
@@ -266,20 +266,20 @@ void AutoStyle()
 	const auto &explicit_ref = RefInt;
 
 	// [cpp.auto.init.lbmd] a generalization of the always-initialized is the
-	//	self calling lambda technique (bonus: very useful for `const`)
+	//  self calling lambda technique (bonus: very useful for `const`)
 	const auto InitLevel = []()
 	{
-	// 	possible example of complicated logic
+	//  possible example of complicated logic
 	// 	that cannot be easily implemented with the ?: operator
 	//
-	//	if (auto CamMgr = (static_cast<ACameraManager *>(PC))->GetCameraManager())
-	//		return CamMgr->GetCurrentHeightLevel();
-	//	else
+	//  if (auto CamMgr = (static_cast<ACameraManager *>(PC))->GetCameraManager())
+	//      return CamMgr->GetCurrentHeightLevel();
+	//  else
 			return 0;
 	}(); // <- called here immediately, so guaranteed to get a default value
 
 	// [cpp.auto.fwd] Don't use `auto &&` unless you know what you are doing
-	//	i.e perfect forwarding inside a lambda
+	//  i.e perfect forwarding inside a lambda
 }
 
 void NoAutoStyle()
@@ -294,22 +294,22 @@ void NoAutoStyle()
 void NumericLimits()
 {
 	// [cpp.numericlimits] Use TNumericLimits instead of #defines such as FLT_MAX
-	// 	See http://api.unrealengine.com/INT/API/Runtime/Core/Math/TNumericLimits/
+	//  See http://api.unrealengine.com/INT/API/Runtime/Core/Math/TNumericLimits/
 
 	// E.g. For all floating point types
-	float MaxPositiveFloatValue = TNumericLimits<float>::Max();
-	float MinPositiveFloatValue = TNumericLimits<float>::Min();
-	float MinNegativeFloatValue = TNumericLimits<float>::Lowest();
+    const float MaxPositiveFloatValue = TNumericLimits<float>::Max();
+    const float MinPositiveFloatValue = TNumericLimits<float>::Min();
+    const float MinNegativeFloatValue = TNumericLimits<float>::Lowest();
 
 	// E.g. For integral types
-	int32 MaxPositiveIntValue = TNumericLimits<int32>::Max();
-	int32 MinNegativeIntValue = TNumericLimits<int32>::Min(); // This is the same as Lowest() for all integral types.
+    const int32 MaxPositiveIntValue = TNumericLimits<int32>::Max();
+    const int32 MinNegativeIntValue = TNumericLimits<int32>::Min(); // This is the same as Lowest() for all integral types.
 }
 
 void ASDCodingStandardExampleActor::BeginPlay()
 {
 	// [ue.ecs.super] always call Super:: method for Actor/Component tickable overridden functions
-	// 	other regular methods don't necessary need to do this
+	//  other regular methods don't necessary need to do this
 	Super::BeginPlay();
 }
 
@@ -324,24 +324,24 @@ void ASDCodingStandardExampleActor::OnRep_WantsToSprint()
 {
 }
 
-void USDCodingStandardExampleComponent::LambdaStyle(AActor *ExternalEntity)
+void USDCodingStandardExampleComponent::LambdaStyle(const AActor& ExternalEntity) const
 {
 	// [cpp.lambda.general] use lambda's to your advantage
-	//	especially when they will isolate work in the implementation
-	//	rather than pollute the interface with helper methods
+	//  especially when they will isolate work in the implementation
+	//  rather than pollute the interface with helper methods
 	//
-	//	but don't abuse them - if their body becomes complex enough
-	//	extract into separate function/method
+	//  but don't abuse them - if their body becomes complex enough
+	//  extract into separate function/method
 
 	// [cpp.lambda.dangling] biggest problem in production is creating dangling references
-	//	by capturing objects by reference that die before the lambda gets called
+	//  by capturing objects by reference that die before the lambda gets called
 	auto lambda_dangling = [ExternalEntity]()
 	{
 		// will ExternalEntity still be valid at this point?
 	};
 
 	// [cpp.lambda.this] don't capture `this`!
-	//	instead use the named captures to cherry pick
+	//  instead use the named captures to cherry pick
 	auto lambda_this = [LocalCopy = this->BlueprintGroup.ShowCameraWidget]()
 	{
 		// LocalCopy available irregardless of the fate of parent
@@ -354,9 +354,9 @@ void USDCodingStandardExampleComponent::LambdaStyle(AActor *ExternalEntity)
 	};
 
 	// [cpp.lambda.auto] the type deduction for the captures are quite convoluted
-	//	- by reference: uses template rules; will preserve `const` and `&`
-	//	- by value: uses template rules; will preserve `const`
-	//	- init capture: uses `auto` rules; WILL MESS UP `const` and `&` (add them back manually)
+	//  - by reference: uses template rules; will preserve `const` and `&`
+	//  - by value: uses template rules; will preserve `const`
+	//  - init capture: uses `auto` rules; WILL MESS UP `const` and `&` (add them back manually)
 	const int Original = 0;
 	const int &Reference = Original;
 	auto lambda_auto = [Original, Duplicate = Original, &RefDuplicate = Original, NotReference = Reference]()
@@ -372,7 +372,7 @@ void USDCodingStandardExampleComponent::LambdaStyle(AActor *ExternalEntity)
 static void EnumString()
 {
 	// [cpp.enum.generated.count] Don't put a label to represent the number of values in the enum
-	// 	use EnumAutoGen::GetNumValues<ESDCodingStandardEnum>() instead.
+	//  use EnumAutoGen::GetNumValues<ESDCodingStandardEnum>() instead.
 	constexpr auto NumValues = EnumAutoGen::GetNumValues<ESDCodingStandardEnum>();
 
 	// [cpp.enum.generated] Use the GenerateStringFuncs parameter if you need string conversion or

--- a/SplashDamageCodingStandard.h
+++ b/SplashDamageCodingStandard.h
@@ -32,11 +32,11 @@
 #pragma once
 
 // [basic.rule] FOLLOW UE4 coding style! 
-//	https://docs.unrealengine.com/latest/INT/Programming/Development/CodingStandard/
-//	especially here in the header/interface
-//	in the implementation (.cpp) you are allowed to diverge a bit for personal taste
-//	but NEVER when it comes to things that will be visible from outside
-//	aka public variables, functions, names etc
+//  https://docs.unrealengine.com/latest/INT/Programming/Development/CodingStandard/
+//  especially here in the header/interface
+//  in the implementation (.cpp) you are allowed to diverge a bit for personal taste
+//  but NEVER when it comes to things that will be visible from outside
+//  aka public variables, functions, names etc
 
 // [header.iwyu] we shall use IWYU https://docs.unrealengine.com/latest/INT/Programming/UnrealBuildSystem/IWYUReferenceGuide/index.html
 #include <CoreMinimal.h>
@@ -44,56 +44,56 @@
 // [header.engine.incl] list all the Engine dependencies with angle brackets includes
 #include <GameFramework/Character.h>
 #include <GameFramework/Pawn.h>
-//	group and separate them by shared logic or purpose
-//	use full relative path (in relation to Engine/Classes folders)
+//  group and separate them by shared logic or purpose
+//  use full relative path (in relation to Engine/Classes folders)
 #include <GameFramework/HUD.h>
 #include <GameFramework/HUDHitBox.h>
 
 // [header.incl.order]
-// Generally speaking the include order of files should be:
-//	1) CoreMinimal
-//	2) Other Engine files
-//	3) SD Core files
-//	4) local includes - with "" style
-//	5) this file .generate.h - with "" style
+//  Generally speaking the include order of files should be:
+//  1) CoreMinimal
+//  2) Other Engine files
+//  3) SD Core files
+//  4) local includes - with "" style
+//  5) this file .generate.h - with "" style
 
 // [header.incl.privatepath]
-// Never include private paths in a public header file. This can cause hard to track linker
-// or compiler errors at a later date. Either re-factor your code so that you can use a forward
-// declare or, if necessary, make the file you are trying to include public.
+//  Never include private paths in a public header file. This can cause hard to track linker
+//  or compiler errors at a later date. Either re-factor your code so that you can use a forward
+//  declare or, if necessary, make the file you are trying to include public.
 
 // [header.incl.gen] always have the .generated files last
 #include "SplashDamageCodingStandard.generated.h"
 
 // [header.rule.fwd] list as many forward declaration as you can
-//	it's also acceptable to declare them at the usage site, but if you find they recur, bring them up here
+//  it's also acceptable to declare them at the usage site, but if you find they recur, bring them up here
 class UInputComponent;
 class UCameraComponent;
 class USkeletalMeshComponent;
 
 UCLASS()
 // [class.name] embed the agreed project codename while following UE4 naming rules. 
-//	- See [module.naming.class]
+//  - See [module.naming.class]
 class ASDCodingStandardExampleActor : public ACharacter
 {
 	GENERATED_BODY() // GENERATED_UCLASS_BODY is deprecated
 
 	// [ue.gen.access] follow up the reflection macros with access level specifiers 
-	// because they don't modify them anymore (used to be the case)
-	// structs do not need to specify public, unless they also specify protected/private (see [ue.gen.struct])
+	//  because they don't modify them anymore (used to be the case)
+	//  structs do not need to specify public, unless they also specify protected/private (see [ue.gen.struct])
 public:
 
 	// [class.ctor.default] don't write an empty one, remove it
-	// 	due to the way GENERATED_BODY works, `= default`-ing the constructor can lead to crashes
+	//  due to the way GENERATED_BODY works, `= default`-ing the constructor can lead to crashes
 
 	// [class.dtor] don't write empty one, default or remove it
-	//	respect the rule of 3/5/0 http://en.cppreference.com/w/cpp/language/rule_of_three
+	//  respect the rule of 3/5/0 http://en.cppreference.com/w/cpp/language/rule_of_three
 	~ASDCodingStandardExampleActor() = default; // or just remove
 
 	// [class.virtual] explicitly mark up virtual methods
-	//	- always use the `override` specifier
-	//  	- use the `final` specifier sparingly and with care as it can have large ramifications on downstream classes.
-	//  	- group overridden functions by the class that first defined, them using begin/end comments (as below)
+	//  - always use the `override` specifier
+	//  - use the `final` specifier sparingly and with care as it can have large ramifications on downstream classes.
+	//  - group overridden functions by the class that first defined, them using begin/end comments (as below)
 
 	// Begin AActor override
 	virtual void BeginPlay() override;
@@ -101,40 +101,40 @@ public:
 	// End AActor override
 
 	// [class.same-line] DON'T write definitions on the same line as declarations!
-	//	it makes debugging impossible
+	//  it makes debugging impossible
 	// [class.inline.bad] NEVER USE `inline or `FORCEINLINE` inside a class declaration
-	//	- it's useless and leads to linking errors
-	//	- definitions(bodies) inside a class/struct are implicitly inline!
+	//  - it's useless and leads to linking errors
+	//  - definitions(bodies) inside a class/struct are implicitly inline!
 	// [comment.useless] DON'T write meaningless comments!
-	//	they should always reflect bigger purpose or reveal hidden details
+	//  they should always reflect bigger purpose or reveal hidden details
 	// Returns Mesh subobject
-	/* BAD -> */ FORCEINLINE USkeletalMeshComponent* GetMesh() const { return MyMesh; } /* <- BAD */
+	/* BAD -> */ FORCEINLINE const USkeletalMeshComponent* GetMesh() const { return MyMesh; } /* <- BAD */
 
 	// [class.inline.good] Move the definitions of inline function outside the class
-	TWeakObjectPtr<USkeletalMeshComponent> GoodExampleOfInline();
+    const USkeletalMeshComponent* GoodExampleOfInline() const;
 
 protected:
 	// [class.order] Do not alternate between functions and variables in the class declaration
-	// 	Put all functions first, all variables last
+	//  Put all functions first, all variables last
 
 	// [ue.ecs.split] Split functionality into components
-	//	avoid creating monolithic giant classes!
+	//  avoid creating monolithic giant classes!
 	// [header.rule.fwd] example of in-place forward declaration
 
 	// [ue.ecs.gc] never use naked pointers to UObject's, always have UPROPERTY or UE smart ptr
-	//	Generally, for storing pointers to classes you don't own, use TWeakObjectPtr.
-	//	Don't initialise TWeakObjectPtr as it will force you to include the header file for the container class.
-	TWeakObjectPtr<USkeletalMeshComponent> OtherMesh; // <- GOOD
+	//  Generally, for storing pointers to classes you don't own, use TWeakObjectPtr.
+	//  Don't initialise TWeakObjectPtr as it will force you to include the header file for the container class.
+	TWeakObjectPtr<const USkeletalMeshComponent> OtherMesh; // <- GOOD
 	//TWeakObjectPtr<USkeletalMeshComponent> AnotherMesh = nullptr; // <- BAD and not compiling
-	//	Generally, for storing pointers to classes you do own, use UPROPERTY() and initialise.
+	//  Generally, for storing pointers to classes you do own, use UPROPERTY() and initialise.
 	UPROPERTY(BlueprintReadOnly, Category = Mesh)
-	USkeletalMeshComponent* MyMesh = nullptr;
-	//	For more information on other forms of UE4 smart pointers see
-	//	https://docs.unrealengine.com/latest/INT/Programming/UnrealArchitecture/SmartPointerLibrary/ 
+	const USkeletalMeshComponent* MyMesh = nullptr;
+	//  For more information on other forms of UE4 smart pointers see
+	//  https://docs.unrealengine.com/latest/INT/Programming/UnrealArchitecture/SmartPointerLibrary/ 
 
 	// [class.order.replication] As an exception to [class.ordering], declare replication functions
-	// 	next to the variable that used them to avoid cluttering the interface with these functions that
-	// 	are not called by client code.
+	//  next to the variable that used them to avoid cluttering the interface with these functions that
+	//  are not called by client code.
 	UPROPERTY(Transient, ReplicatedUsing = "OnRep_WantsToSprint")
 	bool WantsToSprint = false;
 	UFUNCTION()
@@ -142,32 +142,32 @@ protected:
 };
 
 // [ue.gen.struct] [ue.ecs.group] move groups of Blueprint exposed variables into separate structures
-//	this helps refactoring and takes the stress out of interfaces
-//	for ex implementation-only functions can just take the group as an argument
-//	NOTE: this is not always possible, but highly desirable for "config" like variables
+//  this helps refactoring and takes the stress out of interfaces
+//  for ex implementation-only functions can just take the group as an argument
+//  NOTE: this is not always possible, but highly desirable for "config" like variables
 USTRUCT(BlueprintType)
 struct FSDCodingStandardBlueprintVarGroup
 {
 	GENERATED_BODY()
 
 	// [vs.plugin] some good tools to help manage these special meta attributes
-	//	it's a pain to write them by hand
-	//	- UE4 Intellisense https://marketplace.visualstudio.com/items?itemName=RxCompiLe.UE4Intellisense
-	//	- SpecifierTool https://marketplace.visualstudio.com/items?itemName=patience2012.SpecifierTool
+	//  it's a pain to write them by hand
+	//  - UE4 Intellisense https://marketplace.visualstudio.com/items?itemName=RxCompiLe.UE4Intellisense
+	//  - SpecifierTool https://marketplace.visualstudio.com/items?itemName=patience2012.SpecifierTool
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
 	TArray<int> WidgetCameraLevels; // [class.member.def] Unreal arrays start initialized and empty
 
 	// [class.member.def] always provide defaults for member variables
-	//	prefer assigning them here, not in the constructor - that should be reserved
-	//	for more complicated init logic / creation 
+	//  prefer assigning them here, not in the constructor - that should be reserved
+	//  for more complicated init logic / creation 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
 	float CameraTraceVolumeWidth = 96.0f * 5;
 
 	// [class.member.config] member variables that are used as editor config variables
-	//  	MUST have a comment supplied as it shows up as the tooltip in the Editor.
-	//  	They should also be marked as EditDefaultsOnly by default.
-	//  	If you expect them to be read in blueprints then use BlueprintReadOnly.
-	//  	Only use EditAnywhere, EditInstanceOnly or BlueprintReadWrite if it's necessary for your use case.
+	//  MUST have a comment supplied as it shows up as the tooltip in the Editor.
+	//  They should also be marked as EditDefaultsOnly by default.
+	//  If you expect them to be read in blueprints then use BlueprintReadOnly.
+	//  Only use EditAnywhere, EditInstanceOnly or BlueprintReadWrite if it's necessary for your use case.
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
 	float CameraTraceVolumeHeight = 96.0f * 5;
 
@@ -176,15 +176,15 @@ struct FSDCodingStandardBlueprintVarGroup
 	bool ShowCameraWidget = true; 
 
 	// [hardware.cache] for ex grouping similar types like this will minimize the 
-	//	internal padding the compiler will add
-	//	general rule of thumb: sort in descending order by size 
+	//  internal padding the compiler will add
+	//  general rule of thumb: sort in descending order by size 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
 	bool ShowWeaponWidget = true;
 };
 
 // [cpp.enum.strong] use the strongly typed enums rather than old C style + dirty namespace tricks
 // [cpp.enum.generated] Use the GenerateStringFuncs parameter if you need string conversion or
-// 	query the number of values. NOTE: only available on certain projects 
+//  query the number of values. NOTE: only available on certain projects 
 //UENUM(GenerateStringFuncs)
 enum class ESDCodingStandardEnum // `: uint8` optional underlying type 
 {
@@ -193,7 +193,7 @@ enum class ESDCodingStandardEnum // `: uint8` optional underlying type
 	ValueC,
 
 	// [cpp.enum.generated.count] Don't put a label to represent the number of values in the enum
-	// 	use EnumAutoGen::GetNumValues<ESDCodingStandardEnum>() instead.
+	//  use EnumAutoGen::GetNumValues<ESDCodingStandardEnum>() instead.
 	Max // <- BAD
 };
 
@@ -204,43 +204,43 @@ class USDCodingStandardExampleComponent : public USceneComponent
 
 public:
 	// [func.arg.readability] avoid `bool` function arguments, especially successions of them	
-	/* BAD -> */ void FuncHardToReadOnCall(int Order, bool bSetCache, bool bUseLog); /* <- BAD */
+	/* BAD -> */ void FuncHardToReadOnCall(int Order, bool bSetCache, bool bUseLog) const; /* <- BAD */
 	using TOrder = int;
 	enum class ECacheFlags { Use, Disabled, Unspecified };
 	enum class ELogging { Yes, No };
-	/* GOOD -> */ void FuncNiceToReadOnCall(TOrder, ECacheFlags, ELogging);
-	//	argument names in declarations are ignored, try to encode as much meaning as possible in the type
-	//	also even this simple typedef/using goes a long way readability wise at the call site:
-	//	ex: FuncNiceToReadOnCall(FOrder(42), FCacheFlags::Use, FLogFlags::Custom, FLoadOnPlay(false));
+	/* GOOD -> */ void FuncNiceToReadOnCall(TOrder, ECacheFlags, ELogging) const;
+	//  argument names in declarations are ignored, try to encode as much meaning as possible in the type
+	//  also even this simple typedef/using goes a long way readability wise at the call site:
+	//  ex: FuncNiceToReadOnCall(FOrder(42), FCacheFlags::Use, FLogFlags::Custom, FLoadOnPlay(false));
 
 	// [func.arg.readability] avoid consecutive chains of same type, avoid too many arguments
-	/* BAD -> */ void FuncWithTooManyArgs(FVector Location, FVector Origin, FVector EndPoint,
-		FRotator Rotation, UPrimitiveComponent *Parent, AActor *Owner, float Damage, float Radius); /* <- BAD */
-	// try to add a helper structure, or maybe you can split in more functions that are less complex each
+	/* BAD -> */ void FuncWithTooManyArgs(const FVector& Location, const FVector& Origin, const FVector& EndPoint,
+		const FRotator& Rotation, const UPrimitiveComponent& Parent, const AActor& Owner) const; /* <- BAD */
+	//  try to add a helper structure, or maybe you can split in more functions that are less complex each
 
 	// [singleton.no] NEVER USE SINGLETONS!!!
-	//	- they are very problematic in multi-threaded scenarios
-	//	- they interfere/break with Hot Reload and plugins
-	//	- discuss alternatives with your lead
-	//	- if you somehow have to add one, first reconsider, then use the Meyers pattern: https://stackoverflow.com/a/1661564
+	//  - they are very problematic in multi-threaded scenarios
+	//  - they interfere/break with Hot Reload and plugins
+	//  - discuss alternatives with your lead
+	//  - if you somehow have to add one, first reconsider, then use the Meyers pattern: https://stackoverflow.com/a/1661564
 	/* BAD -> */ static USDCodingStandardExampleComponent* Instance; // defined in .cpp
-	/* VERY BAD -> */ USDCodingStandardExampleComponent* GetInstance() { return Instance; }
+	/* VERY BAD -> */ const USDCodingStandardExampleComponent* GetInstance() const { return Instance; }
 
 	// [ue.alloc] expose the allocation as a policy for new utility methods you write
-	//	this way the caller has a chance to decide how memory is utilized
+	//  this way the caller has a chance to decide how memory is utilized
 	template<class AllocatorType>
-	void GetComponents(TArray<UActorComponent *, AllocatorType>& OutComponents);
+	void GetComponents(TArray<const UActorComponent*, AllocatorType>& OutComponents) const;
 
 	// [cpp.lambda] used later for guidelines
-	void LambdaStyle(AActor *ExternalEntity);
+	void LambdaStyle(const AActor& ExternalEntity) const;
 
 	// [cpp.rel_ops] when implementing relation operators, use the binary free form
-	//	as it provides the most flexibility with operands order and usage
-	//	if it needs to access private members, make it `friend` and respect [class.inline.good]
-	// NOTE: add working functionality only for `==` and `<` everything else can be inferred from them
+	//  as it provides the most flexibility with operands order and usage
+	//  if it needs to access private members, make it `friend` and respect [class.inline.good]
+	//  NOTE: add working functionality only for `==` and `<` everything else can be inferred from them
 	friend bool operator == (
-		const USDCodingStandardExampleComponent &lhs,
-		const USDCodingStandardExampleComponent &rhs);
+		const USDCodingStandardExampleComponent& lhs,
+		const USDCodingStandardExampleComponent& rhs);
 
 protected:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
@@ -249,76 +249,76 @@ protected:
 private:
 	// [class.constant] best way to define constants
 	constexpr static int SomeDefaultMagicValue = 0xFF00;
-	// BAD alternatives:
-	//	#define OtherDefaultMagicValue (5)
-	//	enum { RandomSeemValue = 434334 };
-	//	static int AnotherMagicNumber; // actual value buried in .cpp
+	//  BAD alternatives:
+	//      #define OtherDefaultMagicValue (5)
+	//      enum { RandomSeemValue = 434334 };
+	//      static int AnotherMagicNumber; // actual value buried in .cpp
 
 	// [naming.bool] Exception from UE4 coding standard:
-	//	DON'T add `b` prefix to bool declaration names!
-	//	instead use English Modal Verbs and variations like: Can, Does, Will, Is, Has, Use, etc
+	//  DON'T add `b` prefix to bool declaration names!
+	//  instead use English Modal Verbs and variations like: Can, Does, Will, Is, Has, Use, etc
 	bool bInGame, bAttack, bLog, bCustomStencil; /* <- BAD */
 	bool InGame, CanAttack, UseLog, HasCustomStencil; /* <- GOOD */
 };
 
 // [class.inline.good]
-//	- don't use FORCEINLINE unless you really want to persuade the
-//		compiler to inline a complicated function
-//		which is NOT guaranteed to work!
-//	- 100% for one-liners or very simple functions inline-ing will work regardless
-//	- here we have to use the `inline` to allow proper linkage
-//		this simple function would have been inlined anyway
-//	- having it like this also helps refactoring
-//		you can easily move this to the .cpp without messing up the class definition
-inline TWeakObjectPtr<USkeletalMeshComponent> ASDCodingStandardExampleActor::GoodExampleOfInline()
+//  - don't use FORCEINLINE unless you really want to persuade the
+//      compiler to inline a complicated function
+//      which is NOT guaranteed to work!
+//  - 100% for one-liners or very simple functions inline-ing will work regardless
+//  - here we have to use the `inline` to allow proper linkage
+//      this simple function would have been inlined anyway
+//  - having it like this also helps refactoring
+//      you can easily move this to the .cpp without messing up the class definition
+inline const USkeletalMeshComponent* ASDCodingStandardExampleActor::GoodExampleOfInline() const
 {
-	return OtherMesh;
+	return OtherMesh.Get();
 }
 
 // [cpp.rel_ops] when implementing relation operators, use the binary free form
-//	as it provides the most flexibility with operands order and usage
-//	if it needs to access private members, make it `friend` and respect [class.inline.good]
-// NOTE: add working functionality only for `==` and `<` everything else can be inferred from them
+//  as it provides the most flexibility with operands order and usage
+//  if it needs to access private members, make it `friend` and respect [class.inline.good]
+//  NOTE: add working functionality only for `==` and `<` everything else can be inferred from them
 inline bool operator == (
-	const USDCodingStandardExampleComponent &lhs,
-	const USDCodingStandardExampleComponent &rhs)
+	const USDCodingStandardExampleComponent& lhs,
+	const USDCodingStandardExampleComponent& rhs)
 {
 	return lhs.InGame == rhs.InGame;
 }
 
 // [cpp.namepace.public] Use a namespace to contain free functions.
-// 	This helps manage potential name clashes and unity build issues.
+//  This helps manage potential name clashes and unity build issues.
 namespace SDCodingStandardHelpers
 {
 	void PublicHelper(const USDCodingStandardExampleComponent& Object);
 }
 
 // [module.naming] when adding new module folders to the code base follow a consistent naming convention
-//	- Interface modules should be prefixed with Interface.
-//	- Game independent modules should be prefixed with Core.
-//	- Game specific modules do not have any prefix.
-//	- Prototype only modules should be prefixed with Prototype.
-//		- Prototype modules are only temporary modules.
-//		- Prototype modules will never be included in "live" builds.
-//		- Prototype code should be avoided in non-prototype modules.
+//  - Interface modules should be prefixed with Interface.
+//  - Game independent modules should be prefixed with Core.
+//  - Game specific modules do not have any prefix.
+//  - Prototype only modules should be prefixed with Prototype.
+//      - Prototype modules are only temporary modules.
+//      - Prototype modules will never be included in "live" builds.
+//      - Prototype code should be avoided in non-prototype modules.
 
 // [module.naming.class] code in modules should also follow our naming convention
-//	- Interfaces in Interface modules should be prefixed with SDI
-//	- Classes, Struct & Enums in Interface modules should be prefixed with SDC
-//	- Interfaces in Core modules should be prefixed with SDC
-//	- Classes, Struct & Enums in Core modules should be prefixed with SDC
-//	- Interfaces in Game modules should be prefixed with SD
-//	- Classes, Struct & Enums in Game modules should be prefixed with SD
+//  - Interfaces in Interface modules should be prefixed with SDI
+//  - Classes, Struct & Enums in Interface modules should be prefixed with SDC
+//  - Interfaces in Core modules should be prefixed with SDC
+//  - Classes, Struct & Enums in Core modules should be prefixed with SDC
+//  - Interfaces in Game modules should be prefixed with SD
+//  - Classes, Struct & Enums in Game modules should be prefixed with SD
 
 // [module.naming.namespace]
-// 	- Namespaces in Core modules should be prefixed with SDC
-// 	- Namespaces in Game modules should be prefixed with SD
-// 	- Namespaces should be named the same as the file they live in
-// 	- Namespaces may be postfixed with "Helpers" where it prevents ambiguity
+//  - Namespaces in Core modules should be prefixed with SDC
+//  - Namespaces in Game modules should be prefixed with SD
+//  - Namespaces should be named the same as the file they live in
+//  - Namespaces may be postfixed with "Helpers" where it prevents ambiguity
 
 // [module.dependency] modules should follow strict dependency rules
-//	- Interface modules should only include engine modules.
-//	- Core modules should only include engine and interface modules.
-//		- some Core modules such as CoreUtility and CoreTypes are allowed to be included.
-//	- Game modules can include any other non-prototype module.
-//	- Prototype modules can include any other module.
+//  - Interface modules should only include engine modules.
+//  - Core modules should only include engine and interface modules.
+//      - some Core modules such as CoreUtility and CoreTypes are allowed to be included.
+//  - Game modules can include any other non-prototype module.
+//  - Prototype modules can include any other module.

--- a/SplashDamageCodingStandard.h
+++ b/SplashDamageCodingStandard.h
@@ -232,7 +232,7 @@ public:
 	void GetComponents(TArray<const UActorComponent*, AllocatorType>& OutComponents) const;
 
 	// [cpp.lambda] used later for guidelines
-	void LambdaStyle(const AActor& ExternalEntity) const;
+	void LambdaStyle(const AActor* ExternalEntity) const;
 
 	// [cpp.rel_ops] when implementing relation operators, use the binary free form
 	//  as it provides the most flexibility with operands order and usage


### PR DESCRIPTION
Increase const correctness throughout.
Fix whitespacing to be consistent throughout document to not use tabs.
Make pointer and reference style use consistent throughout.