### PR TITLE
Remove Jira tag from engine changes.

### DIFF
--- a/SplashDamageCodingStandard.cpp
+++ b/SplashDamageCodingStandard.cpp
@@ -214,7 +214,7 @@ void EngineChanges()
 {
 	if (true)
 	{
-// @SPLASH_DAMAGE_CHANGE: <author email> - BEGIN: <JIRA tag> <description>
+// @SPLASH_DAMAGE_CHANGE: <author email> - BEGIN: <description>
 		// ...
 // @SPLASH_DAMAGE_CHANGE: <author email> - END
 	}


### PR DESCRIPTION
There’s no guarantee the person looking at the code has JIRA access and having to leave the code to get context on a change is not fun when you are integrating a lot of changes. All necessary information to understand an engine change should be in the code.