### PR TITLE
Remove incorrect point on not initialising TWeakObjPtr

### DIFF
--- a/SplashDamageCodingStandard.cpp
+++ b/SplashDamageCodingStandard.cpp
@@ -67,9 +67,9 @@
 //  defined only in cpp files. Also mark them as static to enforce internal only linkage.
 namespace SDCodingStandardHelpers
 {
-    static void PrivateHelper(const USDCodingStandardExampleComponent& Object)
-    {
-    }
+	static void PrivateHelper(const USDCodingStandardExampleComponent& Object)
+	{
+	}
 }
 
 // [basic.order] respect the order of declarations in the .h header
@@ -78,56 +78,56 @@ namespace SDCodingStandardHelpers
 // [basic.rule.brace] FOLLOW UE4 coding style i.e. Allman style aka one every line
 void BraceStyle()
 {
-    // illustration purpose only - don't do this in live code (use bit sets instead of many bool's)
-    const bool FailCondition = false, TrueCondition = true,
-        SomethingElse = true, Contract = true, Binding = true;
+	// illustration purpose only - don't do this in live code (use bit sets instead of many bool's)
+	const bool FailCondition = false, TrueCondition = true,
+		SomethingElse = true, Contract = true, Binding = true;
 
-    if (FailCondition)
-    {
-        return; // even for one liners
-    }
+	if (FailCondition)
+	{
+		return; // even for one liners
+	}
 
-    if (TrueCondition)
-    {
-        // ...
-    }
-    else if (SomethingElse)
-    {
-        // ...
-    }
-    else // !SomethingElse and !TrueCondition
-    {
-        // ...
-    }
+	if (TrueCondition)
+	{
+		// ...
+	}
+	else if (SomethingElse)
+	{
+		// ...
+	}
+	else // !SomethingElse and !TrueCondition
+	{
+		// ...
+	}
 
-    // for `switch` statements follow Unreal's guideline
-    // https://docs.unrealengine.com/latest/INT/Programming/Development/CodingStandard/#switchstatements
+	// for `switch` statements follow Unreal's guideline
+	// https://docs.unrealengine.com/latest/INT/Programming/Development/CodingStandard/#switchstatements
 
-    // [basic.rule.parens] parenthesis link with the expression not the keyword
-    for (;/*...*/;)
-    {
-    }
+	// [basic.rule.parens] parenthesis link with the expression not the keyword
+	for (;/*...*/;)
+	{
+	}
 
-    // [cpp.return.early] use early returns to avoid excessive nesting
-    //  especially for pre-conditions / contracts
-    //  one exception is logic flow where too many early returns would hurt readability
-    if (!Contract && !Binding)
-    {
-        return;
-    }
-    // versus
-    if (Contract)
-    {
-        if (Binding)
-        {
-        }
-    }
+	// [cpp.return.early] use early returns to avoid excessive nesting
+	//  especially for pre-conditions / contracts
+	//  one exception is logic flow where too many early returns would hurt readability
+	if (!Contract && !Binding)
+	{
+		return;
+	}
+	// versus
+	if (Contract)
+	{
+		if (Binding)
+		{
+		}
+	}
 
-    // [cpp.if.init] use the if-with-initializer idiom
-    if (const bool IsGame = FApp::IsGame())
-    {
-        // ...
-    }
+	// [cpp.if.init] use the if-with-initializer idiom
+	if (const bool IsGame = FApp::IsGame())
+	{
+		// ...
+	}
 }
 
 // [globals.no] avoid globals unless they're POD (plain-old-data)
@@ -136,7 +136,7 @@ void BraceStyle()
 FIntPoint CachedCoordinates; // PASSABLE
 class MyBigObject
 {
-    // ...
+	// ...
 };
 MyBigObject Cache1; // BAD
 MyBigObject Cache2; // BAD - maybe this is started first, not Cache1
@@ -145,8 +145,8 @@ MyBigObject Cache2; // BAD - maybe this is started first, not Cache1
 //  instead of using C style pass by reference
 TOptional<FIntRect> IntersectTest(const FIntPoint& min, const FIntPoint& max)
 {
-    // ...
-    return (min.X > max.X || min.Y > max.Y) ? TOptional<FIntRect>() : FIntRect(min, max);
+	// ...
+	return (min.X > max.X || min.Y > max.Y) ? TOptional<FIntRect>() : FIntRect(min, max);
 }
 
 // [ue.gen.struct] if Blueprint variables are extracted in separate structures
@@ -154,86 +154,86 @@ TOptional<FIntRect> IntersectTest(const FIntPoint& min, const FIntPoint& max)
 //  methods in a class, thus leading to less coupling and faster compilation
 float DoPassBlueprintVarStructs(const FSDCodingStandardBlueprintVarGroup& vars)
 {
-    return vars.CameraTraceVolumeWidth / 2.f;
+	return vars.CameraTraceVolumeWidth / 2.f;
 }
 
 void DontWasteMemory(const AActor& Actor)
 {
-    // [ue.container] Mind your allocations!
-    //  don't go to the heap, go to the stack!
-    TInlineComponentArray<UPrimitiveComponent*> PrimComponents; // 24 item reserved by default
-    Actor.GetComponents(PrimComponents);
+	// [ue.container] Mind your allocations!
+	//  don't go to the heap, go to the stack!
+	TInlineComponentArray<UPrimitiveComponent*> PrimComponents; // 24 item reserved by default
+	Actor.GetComponents(PrimComponents);
 
-    // [ue.container] [ue.ecs.get] Customize the get-ers for this purpose!
-    using TCustomAlloc = TInlineAllocator<32>;
-    TArray<UActorComponent *, TCustomAlloc> LocalItems;
-    Actor.GetComponents<UActorComponent, TCustomAlloc>(LocalItems);
+	// [ue.container] [ue.ecs.get] Customize the get-ers for this purpose!
+	using TCustomAlloc = TInlineAllocator<32>;
+	TArray<UActorComponent *, TCustomAlloc> LocalItems;
+	Actor.GetComponents<UActorComponent, TCustomAlloc>(LocalItems);
 
-    // [ue.container.reserve] Prepare upfront the containers
-    //  cut down on the need to allocate per-item
-    PrimComponents.Reserve(64);
-    PrimComponents.Init(nullptr, 64);
+	// [ue.container.reserve] Prepare upfront the containers
+	//  cut down on the need to allocate per-item
+	PrimComponents.Reserve(64);
+	PrimComponents.Init(nullptr, 64);
 
-    // [ue.container.reset] Don't empty, just reset!
-    PrimComponents.Empty(); // BAD - deallocates for new 0 size
-    PrimComponents.Reset(); // GOOD - same effect, but instant, no realloc
-    PrimComponents.Empty(64); // PASSABLE - empty with slack
+	// [ue.container.reset] Don't empty, just reset!
+	PrimComponents.Empty(); // BAD - deallocates for new 0 size
+	PrimComponents.Reset(); // GOOD - same effect, but instant, no realloc
+	PrimComponents.Empty(64); // PASSABLE - empty with slack
 
-    // [hardware.cache] be mindful of cache access and plan your memory access accordingly
-    //
-    //  1 CPU cycle
-    //  o
-    //
-    //  L1 cache access
-    //  ooo
-    //
-    //  L2 cache access
-    //  ooooooooo
-    //
-    //  L3 cache access
-    //  oooooooooooooooooooooooooooooooooooooooooo
-    //
-    //  Main memory access
-    //  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-    //  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-    //  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-    //  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-    //
-    //  from https://twitter.com/srigi/status/917998817051541504
-    //
-    //  Some general tips
-    //  - prefer linear data structures, don't jump via pointers too much etc
-    //  - all cache access is through lines 64 bytes long, have that in mind!
-    //  - in classes put related data together, group them by algorithm/logic access
-    //  - be mindful of the invisible packing the compiler will do behind your back
-    //      don't intermingle bool's or small types willy nilly with bigger ones etc
+	// [hardware.cache] be mindful of cache access and plan your memory access accordingly
+	//
+	//  1 CPU cycle
+	//  o
+	//
+	//  L1 cache access
+	//  ooo
+	//
+	//  L2 cache access
+	//  ooooooooo
+	//
+	//  L3 cache access
+	//  oooooooooooooooooooooooooooooooooooooooooo
+	//
+	//  Main memory access
+	//  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+	//  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+	//  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+	//  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+	//
+	//  from https://twitter.com/srigi/status/917998817051541504
+	//
+	//  Some general tips
+	//  - prefer linear data structures, don't jump via pointers too much etc
+	//  - all cache access is through lines 64 bytes long, have that in mind!
+	//  - in classes put related data together, group them by algorithm/logic access
+	//  - be mindful of the invisible packing the compiler will do behind your back
+	//      don't intermingle bool's or small types willy nilly with bigger ones etc
 }
 
 // [markup.engine] Use special markers for engine changes
 void EngineChanges()
 {
-    if (true)
-    {
-// @SPLASH_DAMAGE_CHANGE: <author email> - BEGIN: <description>
-                // ...
-// @SPLASH_DAMAGE_CHANGE: <author email> - END
-    }
+	if (true)
+	{
+		// @SPLASH_DAMAGE_CHANGE: <author email> - BEGIN: <description>
+						// ...
+		// @SPLASH_DAMAGE_CHANGE: <author email> - END
+	}
 
-    // - always place the markers at column 1, no matter how indented the modified code is
-    // - if the END tag is too far from the BEGIN, repeat the description
-    // - if code is deleted rather than modified, discuss with lead the right approach
-    //	 i.e. commenting out the section vs actually removing it
+	// - always place the markers at column 1, no matter how indented the modified code is
+	// - if the END tag is too far from the BEGIN, repeat the description
+	// - if code is deleted rather than modified, discuss with lead the right approach
+	//	 i.e. commenting out the section vs actually removing it
 }
 
 void GameWithEditorChanges(const TArray<int>& Widgets)
 {
-    // [markup.editor] isolate Editor specific changes in game code
+	// [markup.editor] isolate Editor specific changes in game code
 #if WITH_EDITOR
-    // ...
+	// ...
 
-    // [assert.editor] never assert in Editor code - try to recover to your best effort!
-    check(Widgets.Num()); // <- BAD, will force-crash and potentially destroy work
-    ensureMsgf(Widgets.Num(), TEXT("Must have widgets selected!")); // <- BETTER, doesn't force-crash
+	// [assert.editor] never assert in Editor code - try to recover to your best effort!
+	check(Widgets.Num()); // <- BAD, will force-crash and potentially destroy work
+	ensureMsgf(Widgets.Num(), TEXT("Must have widgets selected!")); // <- BETTER, doesn't force-crash
 #endif
 }
 
@@ -242,84 +242,84 @@ void GameWithEditorChanges(const TArray<int>& Widgets)
 //  - don't bikeshed over the merits of each style, pick one and stick with it
 void AutoStyle()
 {
-    // [cpp.auto.init] auto forces to have initialization - this is always good
-    auto Int = 42; // an int, if explicitly declared it would have garbage default value
-    auto MoreStuff = 42u; // this is unsigned int;
-    auto EvenMore = 42.f; // float
-    auto Precision = 42.0; // double
-    auto Condition = false; // boolean
-    auto Big = 42ll; // long long
+	// [cpp.auto.init] auto forces to have initialization - this is always good
+	auto Int = 42; // an int, if explicitly declared it would have garbage default value
+	auto MoreStuff = 42u; // this is unsigned int;
+	auto EvenMore = 42.f; // float
+	auto Precision = 42.0; // double
+	auto Condition = false; // boolean
+	auto Big = 42ll; // long long
 
-    int *PtrInt = &Int;
-    int &RefInt = Int;
+	int *PtrInt = &Int;
+	int &RefInt = Int;
 
-    // auto on its own NEVER DEDUCES references or const'ness
-    auto not_what_you_think = static_cast<int &>(Int); // <- BAD: type is `int`
-    auto still_bad = static_cast<const int>(Int); // <- BAD: type is still `int`
+	// auto on its own NEVER DEDUCES references or const'ness
+	auto not_what_you_think = static_cast<int &>(Int); // <- BAD: type is `int`
+	auto still_bad = static_cast<const int>(Int); // <- BAD: type is still `int`
 
-    // [cpp.auto.golden-rule] ALWAYS mark auto with the appropriate qualifiers:
-    //  const, &, * - even if it's superfluous
-    auto &proper_ref = Int;
-    auto &enforce_ref = RefInt;
-    auto hidden_ptr = &Int; // <- BAD even if it still works
-    auto *explicit_ptr = PtrInt;
-    const auto &explicit_ref = RefInt;
+	// [cpp.auto.golden-rule] ALWAYS mark auto with the appropriate qualifiers:
+	//  const, &, * - even if it's superfluous
+	auto &proper_ref = Int;
+	auto &enforce_ref = RefInt;
+	auto hidden_ptr = &Int; // <- BAD even if it still works
+	auto *explicit_ptr = PtrInt;
+	const auto &explicit_ref = RefInt;
 
-    // [cpp.auto.init.lbmd] a generalization of the always-initialized is the
-    //  self calling lambda technique (bonus: very useful for `const`)
-    const auto InitLevel = []()
-    {
-        //  possible example of complicated logic
-        // 	that cannot be easily implemented with the ?: operator
-        //
-        //  if (auto CamMgr = (static_cast<ACameraManager *>(PC))->GetCameraManager())
-        //      return CamMgr->GetCurrentHeightLevel();
-        //  else
-        return 0;
-    }(); // <- called here immediately, so guaranteed to get a default value
+	// [cpp.auto.init.lbmd] a generalization of the always-initialized is the
+	//  self calling lambda technique (bonus: very useful for `const`)
+	const auto InitLevel = []()
+	{
+		//  possible example of complicated logic
+		// 	that cannot be easily implemented with the ?: operator
+		//
+		//  if (auto CamMgr = (static_cast<ACameraManager *>(PC))->GetCameraManager())
+		//      return CamMgr->GetCurrentHeightLevel();
+		//  else
+		return 0;
+	}(); // <- called here immediately, so guaranteed to get a default value
 
-    // [cpp.auto.fwd] Don't use `auto &&` unless you know what you are doing
-    //  i.e perfect forwarding inside a lambda
+	// [cpp.auto.fwd] Don't use `auto &&` unless you know what you are doing
+	//  i.e perfect forwarding inside a lambda
 }
 
 void NoAutoStyle()
 {
-    // just don't use it and move on
-    //
-    // if you work in an area where it started with AutoStyle,
-    // continue it or refactor it all without auto
-    // mix of the 2 styles leads to poor readability and maintainability
+	// just don't use it and move on
+	//
+	// if you work in an area where it started with AutoStyle,
+	// continue it or refactor it all without auto
+	// mix of the 2 styles leads to poor readability and maintainability
 }
 
 void NumericLimits()
 {
-    // [cpp.numericlimits] Use TNumericLimits instead of #defines such as FLT_MAX
-    //  See http://api.unrealengine.com/INT/API/Runtime/Core/Math/TNumericLimits/
+	// [cpp.numericlimits] Use TNumericLimits instead of #defines such as FLT_MAX
+	//  See http://api.unrealengine.com/INT/API/Runtime/Core/Math/TNumericLimits/
 
-    // E.g. For all floating point types
-    const float MaxPositiveFloatValue = TNumericLimits<float>::Max();
-    const float MinPositiveFloatValue = TNumericLimits<float>::Min();
-    const float MinNegativeFloatValue = TNumericLimits<float>::Lowest();
+	// E.g. For all floating point types
+	const float MaxPositiveFloatValue = TNumericLimits<float>::Max();
+	const float MinPositiveFloatValue = TNumericLimits<float>::Min();
+	const float MinNegativeFloatValue = TNumericLimits<float>::Lowest();
 
-    // E.g. For integral types
-    const int32 MaxPositiveIntValue = TNumericLimits<int32>::Max();
-    // This is the same as Lowest() for all integral types.
-    const int32 MinNegativeIntValue = TNumericLimits<int32>::Min();
+	// E.g. For integral types
+	const int32 MaxPositiveIntValue = TNumericLimits<int32>::Max();
+	// This is the same as Lowest() for all integral types.
+	const int32 MinNegativeIntValue = TNumericLimits<int32>::Min();
 }
 
 void ASDCodingStandardExampleActor::BeginPlay()
 {
-    // [ue.ecs.super] always call Super:: method for Actor/Component tickable overridden functions
-    //  other regular methods don't necessary need to do this
-    Super::BeginPlay();
+	// [ue.ecs.super] always call Super:: method for Actor/Component tickable overridden functions
+	//  other regular methods don't necessary need to do this
+	Super::BeginPlay();
 }
 
 void ASDCodingStandardExampleActor::GetLifetimeReplicatedProps(
-    TArray<FLifetimeProperty>& OutLifetimeProps) const
+	TArray<FLifetimeProperty>& OutLifetimeProps) const
 {
-    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
-    DOREPLIFETIME(ASDCodingStandardExampleActor, WantsToSprint);
+	DOREPLIFETIME(ASDCodingStandardExampleActor, WantsToSprint);
 }
 
 void ASDCodingStandardExampleActor::OnRep_WantsToSprint()
@@ -328,67 +328,67 @@ void ASDCodingStandardExampleActor::OnRep_WantsToSprint()
 
 void USDCodingStandardExampleComponent::LambdaStyle(const AActor* ExternalEntity) const
 {
-    // [cpp.lambda.general] use lambda's to your advantage
-    //  especially when they will isolate work in the implementation
-    //  rather than pollute the interface with helper methods
-    //
-    //  but don't abuse them - if their body becomes complex enough
-    //  extract into separate function/method
+	// [cpp.lambda.general] use lambda's to your advantage
+	//  especially when they will isolate work in the implementation
+	//  rather than pollute the interface with helper methods
+	//
+	//  but don't abuse them - if their body becomes complex enough
+	//  extract into separate function/method
 
-    // [cpp.lambda.dangling] biggest problem in production is creating dangling references
-    //  by capturing objects by reference that die before the lambda gets called
-    auto lambda_dangling = [ExternalEntity]()
-    {
-        // will ExternalEntity still be valid at this point?
-    };
+	// [cpp.lambda.dangling] biggest problem in production is creating dangling references
+	//  by capturing objects by reference that die before the lambda gets called
+	auto lambda_dangling = [ExternalEntity]()
+	{
+		// will ExternalEntity still be valid at this point?
+	};
 
-    // [cpp.lambda.this] don't capture `this`!
-    //  instead use the named captures to cherry pick
-    auto lambda_this = [LocalCopy = this->BlueprintGroup.ShowCameraWidget]()
-    {
-        // LocalCopy available irregardless of the fate of parent
-    };
+	// [cpp.lambda.this] don't capture `this`!
+	//  instead use the named captures to cherry pick
+	auto lambda_this = [LocalCopy = this->BlueprintGroup.ShowCameraWidget]()
+	{
+		// LocalCopy available irregardless of the fate of parent
+	};
 
-    // [cpp.lambda.=&] avoid capturing everything by value or worse, by reference!
-    auto lambda_avoid = [&]()
-    {
-        // HERE BE DRAGONS!
-    };
+	// [cpp.lambda.=&] avoid capturing everything by value or worse, by reference!
+	auto lambda_avoid = [&]()
+	{
+		// HERE BE DRAGONS!
+	};
 
-    // [cpp.lambda.auto] the type deduction for the captures are quite convoluted
-    //  - by reference: uses template rules; will preserve `const` and `&`
-    //  - by value: uses template rules; will preserve `const`
-    //  - init capture: uses `auto` rules; WILL MESS UP `const` and `&` (add them back manually)
-    const int Original = 0;
-    const int &Reference = Original;
-    auto lambda_auto =
-        [Original, Duplicate = Original, &RefDuplicate = Original, NotReference = Reference]()
-    {
-        // Original => `const int`
-        // Duplicate => `int`
-        // RefDuplicate => `const int &`
-        // NotReference => `int`
-    };
+	// [cpp.lambda.auto] the type deduction for the captures are quite convoluted
+	//  - by reference: uses template rules; will preserve `const` and `&`
+	//  - by value: uses template rules; will preserve `const`
+	//  - init capture: uses `auto` rules; WILL MESS UP `const` and `&` (add them back manually)
+	const int Original = 0;
+	const int &Reference = Original;
+	auto lambda_auto =
+		[Original, Duplicate = Original, &RefDuplicate = Original, NotReference = Reference]()
+	{
+		// Original => `const int`
+		// Duplicate => `int`
+		// RefDuplicate => `const int &`
+		// NotReference => `int`
+	};
 }
 
 #ifdef PROJECT_HAS_ENUMAUTOGEN
 static void EnumString()
 {
-    // [cpp.enum.generated.count] Don't put a label to represent the number of values in the enum
-    //  use EnumAutoGen::GetNumValues<ESDCodingStandardEnum>() instead.
-    constexpr auto NumValues = EnumAutoGen::GetNumValues<ESDCodingStandardEnum>();
+	// [cpp.enum.generated.count] Don't put a label to represent the number of values in the enum
+	//  use EnumAutoGen::GetNumValues<ESDCodingStandardEnum>() instead.
+	constexpr auto NumValues = EnumAutoGen::GetNumValues<ESDCodingStandardEnum>();
 
-    // [cpp.enum.generated] Use the GenerateStringFuncs parameter if you need string conversion or
-    // 	query the number of values. Don't write boilerplate code for this yourself
-    constexpr auto * ValueAString = EnumAutoGen::GetEnumString(ESDCodingStandardEnum::ValueA);
+	// [cpp.enum.generated] Use the GenerateStringFuncs parameter if you need string conversion or
+	// 	query the number of values. Don't write boilerplate code for this yourself
+	constexpr auto * ValueAString = EnumAutoGen::GetEnumString(ESDCodingStandardEnum::ValueA);
 
-    // [cpp.enum.generated.foreach] Use ForEachPair, ForEachString, ForEachVal functions 
-    // 	if you need to do something for each enum value or string
-    EnumAutoGen::ForEachPair<ESDCodingStandardEnum>(
-        [](ESDCodingStandardEnum Value, const TCHAR * String)
-    {
-        // Do something
-    });
+	// [cpp.enum.generated.foreach] Use ForEachPair, ForEachString, ForEachVal functions 
+	// 	if you need to do something for each enum value or string
+	EnumAutoGen::ForEachPair<ESDCodingStandardEnum>(
+		[](ESDCodingStandardEnum Value, const TCHAR * String)
+	{
+		// Do something
+	});
 }
 #endif
 

--- a/SplashDamageCodingStandard.cpp
+++ b/SplashDamageCodingStandard.cpp
@@ -215,7 +215,7 @@ void EngineChanges()
 	if (true)
 	{
 // @SPLASH_DAMAGE_CHANGE: <author email> - BEGIN: <description>
-	// ...
+		// ...
 // @SPLASH_DAMAGE_CHANGE: <author email> - END
 	}
 

--- a/SplashDamageCodingStandard.cpp
+++ b/SplashDamageCodingStandard.cpp
@@ -67,9 +67,9 @@
 //  defined only in cpp files. Also mark them as static to enforce internal only linkage.
 namespace SDCodingStandardHelpers
 {
-	static void PrivateHelper(const USDCodingStandardExampleComponent& Object)
-	{
-	}
+    static void PrivateHelper(const USDCodingStandardExampleComponent& Object)
+    {
+    }
 }
 
 // [basic.order] respect the order of declarations in the .h header
@@ -78,56 +78,56 @@ namespace SDCodingStandardHelpers
 // [basic.rule.brace] FOLLOW UE4 coding style i.e. Allman style aka one every line
 void BraceStyle()
 {
-	// illustration purpose only - don't do this in live code (use bit sets instead of many bool's)
-	const bool FailCondition = false, TrueCondition = true,
-		SomethingElse = true, Contract = true, Binding = true;
+    // illustration purpose only - don't do this in live code (use bit sets instead of many bool's)
+    const bool FailCondition = false, TrueCondition = true,
+        SomethingElse = true, Contract = true, Binding = true;
 
-	if (FailCondition)
-	{
-		return; // even for one liners
-	}
+    if (FailCondition)
+    {
+        return; // even for one liners
+    }
 
-	if (TrueCondition)
-	{
-		// ...
-	}
-	else if (SomethingElse)
-	{
-		// ...
-	}
-	else // !SomethingElse and !TrueCondition
-	{
-		// ...
-	}
+    if (TrueCondition)
+    {
+        // ...
+    }
+    else if (SomethingElse)
+    {
+        // ...
+    }
+    else // !SomethingElse and !TrueCondition
+    {
+        // ...
+    }
 
-	// for `switch` statements follow Unreal's guideline
-	// https://docs.unrealengine.com/latest/INT/Programming/Development/CodingStandard/#switchstatements
+    // for `switch` statements follow Unreal's guideline
+    // https://docs.unrealengine.com/latest/INT/Programming/Development/CodingStandard/#switchstatements
 
-	// [basic.rule.parens] parenthesis link with the expression not the keyword
-	for (;/*...*/;)
-	{
-	}
-	
-	// [cpp.return.early] use early returns to avoid excessive nesting
-	//  especially for pre-conditions / contracts
-	//  one exception is logic flow where too many early returns would hurt readability
-	if (!Contract && !Binding)
-	{
-		return;
-	}
-	// versus
-	if (Contract)
-	{
-		if (Binding)
-		{
-		}
-	}
+    // [basic.rule.parens] parenthesis link with the expression not the keyword
+    for (;/*...*/;)
+    {
+    }
 
-	// [cpp.if.init] use the if-with-initializer idiom
-	if (const bool IsGame = FApp::IsGame())
-	{
-		// ...
-	}
+    // [cpp.return.early] use early returns to avoid excessive nesting
+    //  especially for pre-conditions / contracts
+    //  one exception is logic flow where too many early returns would hurt readability
+    if (!Contract && !Binding)
+    {
+        return;
+    }
+    // versus
+    if (Contract)
+    {
+        if (Binding)
+        {
+        }
+    }
+
+    // [cpp.if.init] use the if-with-initializer idiom
+    if (const bool IsGame = FApp::IsGame())
+    {
+        // ...
+    }
 }
 
 // [globals.no] avoid globals unless they're POD (plain-old-data)
@@ -136,7 +136,7 @@ void BraceStyle()
 FIntPoint CachedCoordinates; // PASSABLE
 class MyBigObject
 {
-	// ...
+    // ...
 };
 MyBigObject Cache1; // BAD
 MyBigObject Cache2; // BAD - maybe this is started first, not Cache1
@@ -145,8 +145,8 @@ MyBigObject Cache2; // BAD - maybe this is started first, not Cache1
 //  instead of using C style pass by reference
 TOptional<FIntRect> IntersectTest(const FIntPoint& min, const FIntPoint& max)
 {
-	// ...
-	return (min.X > max.X || min.Y > max.Y) ? TOptional<FIntRect>() : FIntRect(min, max);
+    // ...
+    return (min.X > max.X || min.Y > max.Y) ? TOptional<FIntRect>() : FIntRect(min, max);
 }
 
 // [ue.gen.struct] if Blueprint variables are extracted in separate structures
@@ -154,86 +154,86 @@ TOptional<FIntRect> IntersectTest(const FIntPoint& min, const FIntPoint& max)
 //  methods in a class, thus leading to less coupling and faster compilation
 float DoPassBlueprintVarStructs(const FSDCodingStandardBlueprintVarGroup& vars)
 {
-	return vars.CameraTraceVolumeWidth / 2.f;
+    return vars.CameraTraceVolumeWidth / 2.f;
 }
 
 void DontWasteMemory(const AActor& Actor)
 {
-	// [ue.container] Mind your allocations!
-	//  don't go to the heap, go to the stack!
-	TInlineComponentArray<UPrimitiveComponent*> PrimComponents; // 24 item reserved by default
-	Actor.GetComponents(PrimComponents);
-	
-	// [ue.container] [ue.ecs.get] Customize the get-ers for this purpose!
-	using TCustomAlloc = TInlineAllocator<32>;
-	TArray<UActorComponent *, TCustomAlloc> LocalItems;
-	Actor.GetComponents<UActorComponent, TCustomAlloc>(LocalItems);
-	
-	// [ue.container.reserve] Prepare upfront the containers
-	//  cut down on the need to allocate per-item
-	PrimComponents.Reserve(64);
-	PrimComponents.Init(nullptr, 64);
-	
-	// [ue.container.reset] Don't empty, just reset!
-	PrimComponents.Empty(); // BAD - deallocates for new 0 size
-	PrimComponents.Reset(); // GOOD - same effect, but instant, no realloc
-	PrimComponents.Empty(64); // PASSABLE - empty with slack
+    // [ue.container] Mind your allocations!
+    //  don't go to the heap, go to the stack!
+    TInlineComponentArray<UPrimitiveComponent*> PrimComponents; // 24 item reserved by default
+    Actor.GetComponents(PrimComponents);
 
-	// [hardware.cache] be mindful of cache access and plan your memory access accordingly
-	//
-	//  1 CPU cycle
-	//  o
-	//
-	//  L1 cache access
-	//  ooo
-	//
-	//  L2 cache access
-	//  ooooooooo
-	//
-	//  L3 cache access
-	//  oooooooooooooooooooooooooooooooooooooooooo
-	//
-	//  Main memory access
-	//  ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-	//  ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-	//  ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-	//  ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-	//
-	//  from https://twitter.com/srigi/status/917998817051541504
-	//
-	//  Some general tips
-	//  - prefer linear data structures, don't jump via pointers too much etc
-	//  - all cache access is through lines 64 bytes long, have that in mind!
-	//  - in classes put related data together, group them by algorithm/logic access
-	//  - be mindful of the invisible packing the compiler will do behind your back
-	//      don't intermingle bool's or small types willy nilly with bigger ones etc
+    // [ue.container] [ue.ecs.get] Customize the get-ers for this purpose!
+    using TCustomAlloc = TInlineAllocator<32>;
+    TArray<UActorComponent *, TCustomAlloc> LocalItems;
+    Actor.GetComponents<UActorComponent, TCustomAlloc>(LocalItems);
+
+    // [ue.container.reserve] Prepare upfront the containers
+    //  cut down on the need to allocate per-item
+    PrimComponents.Reserve(64);
+    PrimComponents.Init(nullptr, 64);
+
+    // [ue.container.reset] Don't empty, just reset!
+    PrimComponents.Empty(); // BAD - deallocates for new 0 size
+    PrimComponents.Reset(); // GOOD - same effect, but instant, no realloc
+    PrimComponents.Empty(64); // PASSABLE - empty with slack
+
+    // [hardware.cache] be mindful of cache access and plan your memory access accordingly
+    //
+    //  1 CPU cycle
+    //  o
+    //
+    //  L1 cache access
+    //  ooo
+    //
+    //  L2 cache access
+    //  ooooooooo
+    //
+    //  L3 cache access
+    //  oooooooooooooooooooooooooooooooooooooooooo
+    //
+    //  Main memory access
+    //  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+    //  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+    //  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+    //  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+    //
+    //  from https://twitter.com/srigi/status/917998817051541504
+    //
+    //  Some general tips
+    //  - prefer linear data structures, don't jump via pointers too much etc
+    //  - all cache access is through lines 64 bytes long, have that in mind!
+    //  - in classes put related data together, group them by algorithm/logic access
+    //  - be mindful of the invisible packing the compiler will do behind your back
+    //      don't intermingle bool's or small types willy nilly with bigger ones etc
 }
 
 // [markup.engine] Use special markers for engine changes
 void EngineChanges()
 {
-	if (true)
-	{
+    if (true)
+    {
 // @SPLASH_DAMAGE_CHANGE: <author email> - BEGIN: <description>
-		// ...
+                // ...
 // @SPLASH_DAMAGE_CHANGE: <author email> - END
-	}
+    }
 
-	// - always place the markers at column 1, no matter how indented the modified code is
-	// - if the END tag is too far from the BEGIN, repeat the description
-	// - if code is deleted rather than modified, discuss with lead the right approach
-	//	 i.e. commenting out the section vs actually removing it
+    // - always place the markers at column 1, no matter how indented the modified code is
+    // - if the END tag is too far from the BEGIN, repeat the description
+    // - if code is deleted rather than modified, discuss with lead the right approach
+    //	 i.e. commenting out the section vs actually removing it
 }
 
 void GameWithEditorChanges(const TArray<int>& Widgets)
 {
-// [markup.editor] isolate Editor specific changes in game code
+    // [markup.editor] isolate Editor specific changes in game code
 #if WITH_EDITOR
-	// ...
+    // ...
 
-	// [assert.editor] never assert in Editor code - try to recover to your best effort!
-	check(Widgets.Num()); // <- BAD, will force-crash and potentially destroy work
-	ensureMsgf(Widgets.Num(), TEXT("Must have widgets selected!")); // <- BETTER, doesn't force-crash
+    // [assert.editor] never assert in Editor code - try to recover to your best effort!
+    check(Widgets.Num()); // <- BAD, will force-crash and potentially destroy work
+    ensureMsgf(Widgets.Num(), TEXT("Must have widgets selected!")); // <- BETTER, doesn't force-crash
 #endif
 }
 
@@ -242,82 +242,84 @@ void GameWithEditorChanges(const TArray<int>& Widgets)
 //  - don't bikeshed over the merits of each style, pick one and stick with it
 void AutoStyle()
 {
-	// [cpp.auto.init] auto forces to have initialization - this is always good
-	auto Int = 42; // an int, if explicitly declared it would have garbage default value
-	auto MoreStuff = 42u; // this is unsigned int;
-	auto EvenMore = 42.f; // float
-	auto Precision = 42.0; // double
-	auto Condition = false; // boolean
-	auto Big = 42ll; // long long
+    // [cpp.auto.init] auto forces to have initialization - this is always good
+    auto Int = 42; // an int, if explicitly declared it would have garbage default value
+    auto MoreStuff = 42u; // this is unsigned int;
+    auto EvenMore = 42.f; // float
+    auto Precision = 42.0; // double
+    auto Condition = false; // boolean
+    auto Big = 42ll; // long long
 
-	int *PtrInt = &Int;
-	int &RefInt = Int;
+    int *PtrInt = &Int;
+    int &RefInt = Int;
 
-	// auto on its own NEVER DEDUCES references or const'ness
-	auto not_what_you_think = static_cast<int &>(Int); // <- BAD: type is `int`
-	auto still_bad = static_cast<const int>(Int); // <- BAD: type is still `int`
+    // auto on its own NEVER DEDUCES references or const'ness
+    auto not_what_you_think = static_cast<int &>(Int); // <- BAD: type is `int`
+    auto still_bad = static_cast<const int>(Int); // <- BAD: type is still `int`
 
-	// [cpp.auto.golden-rule] ALWAYS mark auto with the appropriate qualifiers:
-	//  const, &, * - even if it's superfluous
-	auto &proper_ref = Int;
-	auto &enforce_ref = RefInt;
-	auto hidden_ptr = &Int; // <- BAD even if it still works
-	auto *explicit_ptr = PtrInt;
-	const auto &explicit_ref = RefInt;
+    // [cpp.auto.golden-rule] ALWAYS mark auto with the appropriate qualifiers:
+    //  const, &, * - even if it's superfluous
+    auto &proper_ref = Int;
+    auto &enforce_ref = RefInt;
+    auto hidden_ptr = &Int; // <- BAD even if it still works
+    auto *explicit_ptr = PtrInt;
+    const auto &explicit_ref = RefInt;
 
-	// [cpp.auto.init.lbmd] a generalization of the always-initialized is the
-	//  self calling lambda technique (bonus: very useful for `const`)
-	const auto InitLevel = []()
-	{
-	//  possible example of complicated logic
-	// 	that cannot be easily implemented with the ?: operator
-	//
-	//  if (auto CamMgr = (static_cast<ACameraManager *>(PC))->GetCameraManager())
-	//      return CamMgr->GetCurrentHeightLevel();
-	//  else
-			return 0;
-	}(); // <- called here immediately, so guaranteed to get a default value
+    // [cpp.auto.init.lbmd] a generalization of the always-initialized is the
+    //  self calling lambda technique (bonus: very useful for `const`)
+    const auto InitLevel = []()
+    {
+        //  possible example of complicated logic
+        // 	that cannot be easily implemented with the ?: operator
+        //
+        //  if (auto CamMgr = (static_cast<ACameraManager *>(PC))->GetCameraManager())
+        //      return CamMgr->GetCurrentHeightLevel();
+        //  else
+        return 0;
+    }(); // <- called here immediately, so guaranteed to get a default value
 
-	// [cpp.auto.fwd] Don't use `auto &&` unless you know what you are doing
-	//  i.e perfect forwarding inside a lambda
+    // [cpp.auto.fwd] Don't use `auto &&` unless you know what you are doing
+    //  i.e perfect forwarding inside a lambda
 }
 
 void NoAutoStyle()
 {
-	// just don't use it and move on
-	//
-	// if you work in an area where it started with AutoStyle,
-	// continue it or refactor it all without auto
-	// mix of the 2 styles leads to poor readability and maintainability
+    // just don't use it and move on
+    //
+    // if you work in an area where it started with AutoStyle,
+    // continue it or refactor it all without auto
+    // mix of the 2 styles leads to poor readability and maintainability
 }
 
 void NumericLimits()
 {
-	// [cpp.numericlimits] Use TNumericLimits instead of #defines such as FLT_MAX
-	//  See http://api.unrealengine.com/INT/API/Runtime/Core/Math/TNumericLimits/
+    // [cpp.numericlimits] Use TNumericLimits instead of #defines such as FLT_MAX
+    //  See http://api.unrealengine.com/INT/API/Runtime/Core/Math/TNumericLimits/
 
-	// E.g. For all floating point types
+    // E.g. For all floating point types
     const float MaxPositiveFloatValue = TNumericLimits<float>::Max();
     const float MinPositiveFloatValue = TNumericLimits<float>::Min();
     const float MinNegativeFloatValue = TNumericLimits<float>::Lowest();
 
-	// E.g. For integral types
+    // E.g. For integral types
     const int32 MaxPositiveIntValue = TNumericLimits<int32>::Max();
-    const int32 MinNegativeIntValue = TNumericLimits<int32>::Min(); // This is the same as Lowest() for all integral types.
+    // This is the same as Lowest() for all integral types.
+    const int32 MinNegativeIntValue = TNumericLimits<int32>::Min();
 }
 
 void ASDCodingStandardExampleActor::BeginPlay()
 {
-	// [ue.ecs.super] always call Super:: method for Actor/Component tickable overridden functions
-	//  other regular methods don't necessary need to do this
-	Super::BeginPlay();
+    // [ue.ecs.super] always call Super:: method for Actor/Component tickable overridden functions
+    //  other regular methods don't necessary need to do this
+    Super::BeginPlay();
 }
 
-void ASDCodingStandardExampleActor::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+void ASDCodingStandardExampleActor::GetLifetimeReplicatedProps(
+    TArray<FLifetimeProperty>& OutLifetimeProps) const
 {
-	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
-	DOREPLIFETIME(ASDCodingStandardExampleActor, WantsToSprint);
+    DOREPLIFETIME(ASDCodingStandardExampleActor, WantsToSprint);
 }
 
 void ASDCodingStandardExampleActor::OnRep_WantsToSprint()
@@ -326,66 +328,67 @@ void ASDCodingStandardExampleActor::OnRep_WantsToSprint()
 
 void USDCodingStandardExampleComponent::LambdaStyle(const AActor* ExternalEntity) const
 {
-	// [cpp.lambda.general] use lambda's to your advantage
-	//  especially when they will isolate work in the implementation
-	//  rather than pollute the interface with helper methods
-	//
-	//  but don't abuse them - if their body becomes complex enough
-	//  extract into separate function/method
+    // [cpp.lambda.general] use lambda's to your advantage
+    //  especially when they will isolate work in the implementation
+    //  rather than pollute the interface with helper methods
+    //
+    //  but don't abuse them - if their body becomes complex enough
+    //  extract into separate function/method
 
-	// [cpp.lambda.dangling] biggest problem in production is creating dangling references
-	//  by capturing objects by reference that die before the lambda gets called
-	auto lambda_dangling = [ExternalEntity]()
-	{
-		// will ExternalEntity still be valid at this point?
-	};
+    // [cpp.lambda.dangling] biggest problem in production is creating dangling references
+    //  by capturing objects by reference that die before the lambda gets called
+    auto lambda_dangling = [ExternalEntity]()
+    {
+        // will ExternalEntity still be valid at this point?
+    };
 
-	// [cpp.lambda.this] don't capture `this`!
-	//  instead use the named captures to cherry pick
-	auto lambda_this = [LocalCopy = this->BlueprintGroup.ShowCameraWidget]()
-	{
-		// LocalCopy available irregardless of the fate of parent
-	};
+    // [cpp.lambda.this] don't capture `this`!
+    //  instead use the named captures to cherry pick
+    auto lambda_this = [LocalCopy = this->BlueprintGroup.ShowCameraWidget]()
+    {
+        // LocalCopy available irregardless of the fate of parent
+    };
 
-	// [cpp.lambda.=&] avoid capturing everything by value or worse, by reference!
-	auto lambda_avoid = [&]()
-	{
-		// HERE BE DRAGONS!
-	};
+    // [cpp.lambda.=&] avoid capturing everything by value or worse, by reference!
+    auto lambda_avoid = [&]()
+    {
+        // HERE BE DRAGONS!
+    };
 
-	// [cpp.lambda.auto] the type deduction for the captures are quite convoluted
-	//  - by reference: uses template rules; will preserve `const` and `&`
-	//  - by value: uses template rules; will preserve `const`
-	//  - init capture: uses `auto` rules; WILL MESS UP `const` and `&` (add them back manually)
-	const int Original = 0;
-	const int &Reference = Original;
-	auto lambda_auto = [Original, Duplicate = Original, &RefDuplicate = Original, NotReference = Reference]()
-	{
-		// Original => `const int`
-		// Duplicate => `int`
-		// RefDuplicate => `const int &`
-		// NotReference => `int`
-	};
+    // [cpp.lambda.auto] the type deduction for the captures are quite convoluted
+    //  - by reference: uses template rules; will preserve `const` and `&`
+    //  - by value: uses template rules; will preserve `const`
+    //  - init capture: uses `auto` rules; WILL MESS UP `const` and `&` (add them back manually)
+    const int Original = 0;
+    const int &Reference = Original;
+    auto lambda_auto =
+        [Original, Duplicate = Original, &RefDuplicate = Original, NotReference = Reference]()
+    {
+        // Original => `const int`
+        // Duplicate => `int`
+        // RefDuplicate => `const int &`
+        // NotReference => `int`
+    };
 }
 
 #ifdef PROJECT_HAS_ENUMAUTOGEN
 static void EnumString()
 {
-	// [cpp.enum.generated.count] Don't put a label to represent the number of values in the enum
-	//  use EnumAutoGen::GetNumValues<ESDCodingStandardEnum>() instead.
-	constexpr auto NumValues = EnumAutoGen::GetNumValues<ESDCodingStandardEnum>();
+    // [cpp.enum.generated.count] Don't put a label to represent the number of values in the enum
+    //  use EnumAutoGen::GetNumValues<ESDCodingStandardEnum>() instead.
+    constexpr auto NumValues = EnumAutoGen::GetNumValues<ESDCodingStandardEnum>();
 
-	// [cpp.enum.generated] Use the GenerateStringFuncs parameter if you need string conversion or
-	// 	query the number of values. Don't write boilerplate code for this yourself
-	constexpr auto * ValueAString = EnumAutoGen::GetEnumString(ESDCodingStandardEnum::ValueA);
+    // [cpp.enum.generated] Use the GenerateStringFuncs parameter if you need string conversion or
+    // 	query the number of values. Don't write boilerplate code for this yourself
+    constexpr auto * ValueAString = EnumAutoGen::GetEnumString(ESDCodingStandardEnum::ValueA);
 
-	// [cpp.enum.generated.foreach] Use ForEachPair, ForEachString, ForEachVal functions 
-	// 	if you need to do something for each enum value or string
-	EnumAutoGen::ForEachPair<ESDCodingStandardEnum>(
-		[](ESDCodingStandardEnum Value, const TCHAR * String)
-	{
-		// Do something
-	});
+    // [cpp.enum.generated.foreach] Use ForEachPair, ForEachString, ForEachVal functions 
+    // 	if you need to do something for each enum value or string
+    EnumAutoGen::ForEachPair<ESDCodingStandardEnum>(
+        [](ESDCodingStandardEnum Value, const TCHAR * String)
+    {
+        // Do something
+    });
 }
 #endif
 

--- a/SplashDamageCodingStandard.cpp
+++ b/SplashDamageCodingStandard.cpp
@@ -214,9 +214,9 @@ void EngineChanges()
 {
 	if (true)
 	{
-		// @SPLASH_DAMAGE_CHANGE: <author email> - BEGIN: <description>
-						// ...
-		// @SPLASH_DAMAGE_CHANGE: <author email> - END
+// @SPLASH_DAMAGE_CHANGE: <author email> - BEGIN: <description>
+	// ...
+// @SPLASH_DAMAGE_CHANGE: <author email> - END
 	}
 
 	// - always place the markers at column 1, no matter how indented the modified code is

--- a/SplashDamageCodingStandard.h
+++ b/SplashDamageCodingStandard.h
@@ -125,7 +125,7 @@ protected:
 	TWeakObjectPtr<const USkeletalMeshComponent> OtherMesh = nullptr;
 	//  Generally, for storing pointers to classes you do own, use UPROPERTY().
 	UPROPERTY(BlueprintReadOnly, Category = Mesh)
-		const USkeletalMeshComponent* MyMesh = nullptr;
+	const USkeletalMeshComponent* MyMesh = nullptr;
 	//  For more information on other forms of UE4 smart pointers see
 	//  https://docs.unrealengine.com/latest/INT/Programming/UnrealArchitecture/SmartPointerLibrary/ 
 
@@ -133,9 +133,9 @@ protected:
 	//  next to the variable that used them to avoid cluttering the interface with these functions 
 	//  that are not called by client code.
 	UPROPERTY(Transient, ReplicatedUsing = "OnRep_WantsToSprint")
-		bool WantsToSprint = false;
+	bool WantsToSprint = false;
 	UFUNCTION()
-		void OnRep_WantsToSprint();
+	void OnRep_WantsToSprint();
 };
 
 // [ue.gen.struct] [ue.ecs.group] move groups of Blueprint exposed variables into separate structures
@@ -147,18 +147,18 @@ struct FSDCodingStandardBlueprintVarGroup
 {
 	GENERATED_BODY()
 
-		// [vs.plugin] some good tools to help manage these special meta attributes
-		//  it's a pain to write them by hand
-		//  - UE4 Intellisense https://marketplace.visualstudio.com/items?itemName=RxCompiLe.UE4Intellisense
-		//  - SpecifierTool https://marketplace.visualstudio.com/items?itemName=patience2012.SpecifierTool
-		UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-		TArray<int> WidgetCameraLevels; // [class.member.def] Unreal arrays start initialized and empty
-
-		// [class.member.def] always provide defaults for member variables
-		//  prefer assigning them here, not in the constructor - that should be reserved
-		//  for more complicated init logic / creation 
+	// [vs.plugin] some good tools to help manage these special meta attributes
+	//  it's a pain to write them by hand
+	//  - UE4 Intellisense https://marketplace.visualstudio.com/items?itemName=RxCompiLe.UE4Intellisense
+	//  - SpecifierTool https://marketplace.visualstudio.com/items?itemName=patience2012.SpecifierTool
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-		float CameraTraceVolumeWidth = 96.0f * 5;
+	TArray<int> WidgetCameraLevels; // [class.member.def] Unreal arrays start initialized and empty
+
+	// [class.member.def] always provide defaults for member variables
+	//  prefer assigning them here, not in the constructor - that should be reserved
+	//  for more complicated init logic / creation 
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
+	float CameraTraceVolumeWidth = 96.0f * 5;
 
 	// [class.member.config] member variables that are used as editor config variables
 	//  MUST have a comment supplied as it shows up as the tooltip in the Editor.
@@ -166,17 +166,17 @@ struct FSDCodingStandardBlueprintVarGroup
 	//  If you expect them to be read in blueprints then use BlueprintReadOnly.
 	//  Only use EditAnywhere, EditInstanceOnly or BlueprintReadWrite if it's necessary for your use case.
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-		float CameraTraceVolumeHeight = 96.0f * 5;
+	float CameraTraceVolumeHeight = 96.0f * 5;
 
 	// [hardware.cache] try to order data members with cache and alignment in mind
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-		bool ShowCameraWidget = true;
+	bool ShowCameraWidget = true;
 
 	// [hardware.cache] for ex grouping similar types like this will minimize the 
 	//  internal padding the compiler will add
 	//  general rule of thumb: sort in descending order by size 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-		bool ShowWeaponWidget = true;
+	bool ShowWeaponWidget = true;
 };
 
 // [cpp.enum.strong] use the strongly typed enums rather than old C style + dirty namespace tricks
@@ -212,8 +212,8 @@ public:
 
 	// [func.arg.readability] avoid consecutive chains of same type, avoid too many arguments
 	/* BAD -> */ void FuncWithTooManyArgs(const FVector& Location, const FVector& Origin,
-		const FVector& EndPoint, const FRotator& Rotation, const UPrimitiveComponent& Parent,
-		const AActor& Owner) const; /* <- BAD */
+	const FVector& EndPoint, const FRotator& Rotation, const UPrimitiveComponent& Parent,
+	const AActor& Owner) const; /* <- BAD */
 	//  try to add a helper structure, or possibly split into more functions that are less complex
 
 	// [singleton.no] NEVER USE SINGLETONS!!!

--- a/SplashDamageCodingStandard.h
+++ b/SplashDamageCodingStandard.h
@@ -243,7 +243,7 @@ public:
 
 protected:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
-		FSDCodingStandardBlueprintVarGroup BlueprintGroup;
+	FSDCodingStandardBlueprintVarGroup BlueprintGroup;
 
 private:
 	// [class.constant] best way to define constants

--- a/SplashDamageCodingStandard.h
+++ b/SplashDamageCodingStandard.h
@@ -38,7 +38,8 @@
 //  but NEVER when it comes to things that will be visible from outside
 //  aka public variables, functions, names etc
 
-// [header.iwyu] we shall use IWYU https://docs.unrealengine.com/latest/INT/Programming/UnrealBuildSystem/IWYUReferenceGuide/index.html
+// [header.iwyu] we shall use IWYU 
+//  https://docs.unrealengine.com/latest/INT/Programming/UnrealBuildSystem/IWYUReferenceGuide/index.html
 #include <CoreMinimal.h>
 
 // [header.engine.incl] list all the Engine dependencies with angle brackets includes
@@ -66,7 +67,7 @@
 #include "SplashDamageCodingStandard.generated.h"
 
 // [header.rule.fwd] list as many forward declaration as you can
-//  it's also acceptable to declare them at the usage site, but if you find they recur, bring them up here
+//  it's also acceptable to declare them at the usage site, but if they recur, bring them up here
 class UInputComponent;
 class UCameraComponent;
 class USkeletalMeshComponent;
@@ -76,69 +77,65 @@ UCLASS()
 //  - See [module.naming.class]
 class ASDCodingStandardExampleActor : public ACharacter
 {
-	GENERATED_BODY() // GENERATED_UCLASS_BODY is deprecated
+    GENERATED_BODY() // GENERATED_UCLASS_BODY is deprecated
 
-	// [ue.gen.access] follow up the reflection macros with access level specifiers 
-	//  because they don't modify them anymore (used to be the case)
-	//  structs do not need to specify public, unless they also specify protected/private (see [ue.gen.struct])
+    // [ue.gen.access] follow up the reflection macros with access level specifiers 
+    //  because they don't modify them anymore (used to be the case)
+    //  structs do not need to specify public, unless they also specify protected/private (see [ue.gen.struct])
 public:
 
-	// [class.ctor.default] don't write an empty one, remove it
-	//  due to the way GENERATED_BODY works, `= default`-ing the constructor can lead to crashes
+    // [class.ctor.default] don't write an empty one, remove it
+    //  due to the way GENERATED_BODY works, `= default`-ing the constructor can lead to crashes
 
-	// [class.dtor] don't write empty one, default or remove it
-	//  respect the rule of 3/5/0 http://en.cppreference.com/w/cpp/language/rule_of_three
-	~ASDCodingStandardExampleActor() = default; // or just remove
+    // [class.dtor] don't write empty one, default or remove it
+    //  respect the rule of 3/5/0 http://en.cppreference.com/w/cpp/language/rule_of_three
+    ~ASDCodingStandardExampleActor() = default; // or just remove
 
-	// [class.virtual] explicitly mark up virtual methods
-	//  - always use the `override` specifier
-	//  - use the `final` specifier sparingly and with care as it can have large ramifications on downstream classes.
-	//  - group overridden functions by the class that first defined, them using begin/end comments (as below)
+    // [class.virtual] explicitly mark up virtual methods
+    //  - always use the `override` specifier
+    //  - use the `final` specifier with care as it can have large ramifications on downstream classes.
+    //  - group overridden functions by the class that first defined, them using begin/end comments
+    // Begin AActor override
+    virtual void BeginPlay() override;
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+    // End AActor override
 
-	// Begin AActor override
-	virtual void BeginPlay() override;
-	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
-	// End AActor override
+    // [class.same-line] DON'T write definitions on the same line as declarations!
+    //  it makes debugging impossible
+    // [class.inline.bad] NEVER USE `inline or `FORCEINLINE` inside a class declaration
+    //  - it's useless and leads to linking errors
+    //  - definitions(bodies) inside a class/struct are implicitly inline!
+    // [comment.useless] DON'T write meaningless comments!
+    //  they should always reflect bigger purpose or reveal hidden details
+    // Returns Mesh subobject
+    /* BAD -> */ FORCEINLINE const USkeletalMeshComponent* GetMesh() const { return MyMesh; } /* <- BAD */
 
-	// [class.same-line] DON'T write definitions on the same line as declarations!
-	//  it makes debugging impossible
-	// [class.inline.bad] NEVER USE `inline or `FORCEINLINE` inside a class declaration
-	//  - it's useless and leads to linking errors
-	//  - definitions(bodies) inside a class/struct are implicitly inline!
-	// [comment.useless] DON'T write meaningless comments!
-	//  they should always reflect bigger purpose or reveal hidden details
-	// Returns Mesh subobject
-	/* BAD -> */ FORCEINLINE const USkeletalMeshComponent* GetMesh() const { return MyMesh; } /* <- BAD */
-
-	// [class.inline.good] Move the definitions of inline function outside the class
+    // [class.inline.good] Move the definitions of inline function outside the class
     const USkeletalMeshComponent* GoodExampleOfInline() const;
 
 protected:
-	// [class.order] Do not alternate between functions and variables in the class declaration
-	//  Put all functions first, all variables last
+    // [class.order] Do not alternate between functions and variables in the class declaration
+    //  Put all functions first, all variables last
 
-	// [ue.ecs.split] Split functionality into components
-	//  avoid creating monolithic giant classes!
-	// [header.rule.fwd] example of in-place forward declaration
+    // [ue.ecs.split] Split functionality into components
+    //  avoid creating monolithic giant classes!
 
-	// [ue.ecs.gc] never use naked pointers to UObject's, always have UPROPERTY or UE smart ptr
-	//  Generally, for storing pointers to classes you don't own, use TWeakObjectPtr.
-	//  Don't initialise TWeakObjectPtr as it will force you to include the header file for the container class.
-	TWeakObjectPtr<const USkeletalMeshComponent> OtherMesh; // <- GOOD
-	//TWeakObjectPtr<USkeletalMeshComponent> AnotherMesh = nullptr; // <- BAD and not compiling
-	//  Generally, for storing pointers to classes you do own, use UPROPERTY() and initialise.
-	UPROPERTY(BlueprintReadOnly, Category = Mesh)
-	const USkeletalMeshComponent* MyMesh = nullptr;
-	//  For more information on other forms of UE4 smart pointers see
-	//  https://docs.unrealengine.com/latest/INT/Programming/UnrealArchitecture/SmartPointerLibrary/ 
+    // [ue.ecs.gc] never use naked pointers to UObject's, always have UPROPERTY or UE smart ptr
+    //  Generally, for storing pointers to classes you don't own, use TWeakObjectPtr.
+    TWeakObjectPtr<const USkeletalMeshComponent> OtherMesh = nullptr;
+    //  Generally, for storing pointers to classes you do own, use UPROPERTY().
+    UPROPERTY(BlueprintReadOnly, Category = Mesh)
+        const USkeletalMeshComponent* MyMesh = nullptr;
+    //  For more information on other forms of UE4 smart pointers see
+    //  https://docs.unrealengine.com/latest/INT/Programming/UnrealArchitecture/SmartPointerLibrary/ 
 
-	// [class.order.replication] As an exception to [class.ordering], declare replication functions
-	//  next to the variable that used them to avoid cluttering the interface with these functions that
-	//  are not called by client code.
-	UPROPERTY(Transient, ReplicatedUsing = "OnRep_WantsToSprint")
-	bool WantsToSprint = false;
-	UFUNCTION()
-	void OnRep_WantsToSprint();
+    // [class.order.replication] As an exception to [class.ordering], declare replication functions
+    //  next to the variable that used them to avoid cluttering the interface with these functions 
+    //  that are not called by client code.
+    UPROPERTY(Transient, ReplicatedUsing = "OnRep_WantsToSprint")
+        bool WantsToSprint = false;
+    UFUNCTION()
+        void OnRep_WantsToSprint();
 };
 
 // [ue.gen.struct] [ue.ecs.group] move groups of Blueprint exposed variables into separate structures
@@ -148,38 +145,38 @@ protected:
 USTRUCT(BlueprintType)
 struct FSDCodingStandardBlueprintVarGroup
 {
-	GENERATED_BODY()
+    GENERATED_BODY()
 
-	// [vs.plugin] some good tools to help manage these special meta attributes
-	//  it's a pain to write them by hand
-	//  - UE4 Intellisense https://marketplace.visualstudio.com/items?itemName=RxCompiLe.UE4Intellisense
-	//  - SpecifierTool https://marketplace.visualstudio.com/items?itemName=patience2012.SpecifierTool
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-	TArray<int> WidgetCameraLevels; // [class.member.def] Unreal arrays start initialized and empty
+        // [vs.plugin] some good tools to help manage these special meta attributes
+        //  it's a pain to write them by hand
+        //  - UE4 Intellisense https://marketplace.visualstudio.com/items?itemName=RxCompiLe.UE4Intellisense
+        //  - SpecifierTool https://marketplace.visualstudio.com/items?itemName=patience2012.SpecifierTool
+        UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
+        TArray<int> WidgetCameraLevels; // [class.member.def] Unreal arrays start initialized and empty
 
-	// [class.member.def] always provide defaults for member variables
-	//  prefer assigning them here, not in the constructor - that should be reserved
-	//  for more complicated init logic / creation 
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-	float CameraTraceVolumeWidth = 96.0f * 5;
+        // [class.member.def] always provide defaults for member variables
+        //  prefer assigning them here, not in the constructor - that should be reserved
+        //  for more complicated init logic / creation 
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
+        float CameraTraceVolumeWidth = 96.0f * 5;
 
-	// [class.member.config] member variables that are used as editor config variables
-	//  MUST have a comment supplied as it shows up as the tooltip in the Editor.
-	//  They should also be marked as EditDefaultsOnly by default.
-	//  If you expect them to be read in blueprints then use BlueprintReadOnly.
-	//  Only use EditAnywhere, EditInstanceOnly or BlueprintReadWrite if it's necessary for your use case.
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-	float CameraTraceVolumeHeight = 96.0f * 5;
+    // [class.member.config] member variables that are used as editor config variables
+    //  MUST have a comment supplied as it shows up as the tooltip in the Editor.
+    //  They should also be marked as EditDefaultsOnly by default.
+    //  If you expect them to be read in blueprints then use BlueprintReadOnly.
+    //  Only use EditAnywhere, EditInstanceOnly or BlueprintReadWrite if it's necessary for your use case.
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
+        float CameraTraceVolumeHeight = 96.0f * 5;
 
-	// [hardware.cache] try to order data members with cache and alignment in mind
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-	bool ShowCameraWidget = true; 
+    // [hardware.cache] try to order data members with cache and alignment in mind
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
+        bool ShowCameraWidget = true;
 
-	// [hardware.cache] for ex grouping similar types like this will minimize the 
-	//  internal padding the compiler will add
-	//  general rule of thumb: sort in descending order by size 
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-	bool ShowWeaponWidget = true;
+    // [hardware.cache] for ex grouping similar types like this will minimize the 
+    //  internal padding the compiler will add
+    //  general rule of thumb: sort in descending order by size 
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
+        bool ShowWeaponWidget = true;
 };
 
 // [cpp.enum.strong] use the strongly typed enums rather than old C style + dirty namespace tricks
@@ -188,77 +185,79 @@ struct FSDCodingStandardBlueprintVarGroup
 //UENUM(GenerateStringFuncs)
 enum class ESDCodingStandardEnum // `: uint8` optional underlying type 
 {
-	ValueA,
-	ValueB,
-	ValueC,
+    ValueA,
+    ValueB,
+    ValueC,
 
-	// [cpp.enum.generated.count] Don't put a label to represent the number of values in the enum
-	//  use EnumAutoGen::GetNumValues<ESDCodingStandardEnum>() instead.
-	Max // <- BAD
+    // [cpp.enum.generated.count] Don't put a label to represent the number of values in the enum
+    //  use EnumAutoGen::GetNumValues<ESDCodingStandardEnum>() instead.
+    Max // <- BAD
 };
 
 UCLASS()
 class USDCodingStandardExampleComponent : public USceneComponent
 {
-	GENERATED_BODY()
+    GENERATED_BODY()
 
 public:
-	// [func.arg.readability] avoid `bool` function arguments, especially successions of them	
-	/* BAD -> */ void FuncHardToReadOnCall(int Order, bool bSetCache, bool bUseLog) const; /* <- BAD */
-	using TOrder = int;
-	enum class ECacheFlags { Use, Disabled, Unspecified };
-	enum class ELogging { Yes, No };
-	/* GOOD -> */ void FuncNiceToReadOnCall(TOrder, ECacheFlags, ELogging) const;
-	//  argument names in declarations are ignored, try to encode as much meaning as possible in the type
-	//  also even this simple typedef/using goes a long way readability wise at the call site:
-	//  ex: FuncNiceToReadOnCall(FOrder(42), FCacheFlags::Use, FLogFlags::Custom, FLoadOnPlay(false));
+    // [func.arg.readability] avoid `bool` function arguments, especially successions of them	
+    /* BAD -> */ void FuncHardToReadOnCall(int Order, bool bSetCache, bool bUseLog) const; /* <- BAD */
+    using TOrder = int;
+    enum class ECacheFlags { Use, Disabled, Unspecified };
+    enum class ELogging { Yes, No };
+    /* GOOD -> */ void FuncNiceToReadOnCall(TOrder, ECacheFlags, ELogging) const;
+    //  argument names in declarations are ignored, try to encode as much meaning as possible in the
+    //  type also even this simple typedef/using goes a long way readability wise at the call site:
+    //  ex: FuncNiceToReadOnCall(FOrder(42), FCacheFlags::Use, FLogFlags::Custom, FLoadOnPlay(false));
 
-	// [func.arg.readability] avoid consecutive chains of same type, avoid too many arguments
-	/* BAD -> */ void FuncWithTooManyArgs(const FVector& Location, const FVector& Origin, const FVector& EndPoint,
-		const FRotator& Rotation, const UPrimitiveComponent& Parent, const AActor& Owner) const; /* <- BAD */
-	//  try to add a helper structure, or maybe you can split in more functions that are less complex each
+    // [func.arg.readability] avoid consecutive chains of same type, avoid too many arguments
+    /* BAD -> */ void FuncWithTooManyArgs(const FVector& Location, const FVector& Origin,
+        const FVector& EndPoint, const FRotator& Rotation, const UPrimitiveComponent& Parent,
+        const AActor& Owner) const; /* <- BAD */
+    //  try to add a helper structure, or possibly split into more functions that are less complex
 
-	// [singleton.no] NEVER USE SINGLETONS!!!
-	//  - they are very problematic in multi-threaded scenarios
-	//  - they interfere/break with Hot Reload and plugins
-	//  - discuss alternatives with your lead
-	//  - if you somehow have to add one, first reconsider, then use the Meyers pattern: https://stackoverflow.com/a/1661564
-	/* BAD -> */ static USDCodingStandardExampleComponent* Instance; // defined in .cpp
-	/* VERY BAD -> */ const USDCodingStandardExampleComponent* GetInstance() const { return Instance; }
+    // [singleton.no] NEVER USE SINGLETONS!!!
+    //  - they are very problematic in multi-threaded scenarios
+    //  - they interfere/break with Hot Reload and plugins
+    //  - discuss alternatives with your lead
+    //  - if you somehow have to add one, first reconsider
+    //    - then use the Meyers pattern: https://stackoverflow.com/a/1661564
+    /* BAD -> */ static USDCodingStandardExampleComponent* Instance; // defined in .cpp
+    /* VERY BAD -> */ const USDCodingStandardExampleComponent* GetInstance() const { return Instance; }
 
-	// [ue.alloc] expose the allocation as a policy for new utility methods you write
-	//  this way the caller has a chance to decide how memory is utilized
-	template<class AllocatorType>
-	void GetComponents(TArray<const UActorComponent*, AllocatorType>& OutComponents) const;
+    // [ue.alloc] expose the allocation as a policy for new utility methods you write
+    //  this way the caller has a chance to decide how memory is utilized
+    template<class AllocatorType>
+    void GetComponents(TArray<const UActorComponent*, AllocatorType>& OutComponents) const;
 
-	// [cpp.lambda] used later for guidelines
-	void LambdaStyle(const AActor* ExternalEntity) const;
+    // [cpp.lambda] used later for guidelines
+    void LambdaStyle(const AActor* ExternalEntity) const;
 
-	// [cpp.rel_ops] when implementing relation operators, use the binary free form
-	//  as it provides the most flexibility with operands order and usage
-	//  if it needs to access private members, make it `friend` and respect [class.inline.good]
-	//  NOTE: add working functionality only for `==` and `<` everything else can be inferred from them
-	friend bool operator == (
-		const USDCodingStandardExampleComponent& lhs,
-		const USDCodingStandardExampleComponent& rhs);
+    // [cpp.rel_ops] when implementing relation operators, use the binary free form
+    //  as it provides the most flexibility with operands order and usage
+    //  if it needs to access private members, make it `friend` and respect [class.inline.good]
+    //  NOTE: add working functionality only for `==` and `<` everything else can be inferred
+    friend bool operator == (
+        const USDCodingStandardExampleComponent& lhs,
+        const USDCodingStandardExampleComponent& rhs);
 
 protected:
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
-	FSDCodingStandardBlueprintVarGroup BlueprintGroup;
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+        FSDCodingStandardBlueprintVarGroup BlueprintGroup;
 
 private:
-	// [class.constant] best way to define constants
-	constexpr static int SomeDefaultMagicValue = 0xFF00;
-	//  BAD alternatives:
-	//      #define OtherDefaultMagicValue (5)
-	//      enum { RandomSeemValue = 434334 };
-	//      static int AnotherMagicNumber; // actual value buried in .cpp
+    // [class.constant] best way to define constants
+    constexpr static int SomeDefaultMagicValue = 0xFF00;
+    //  BAD alternatives:
+    //      #define OtherDefaultMagicValue (5)
+    //      enum { RandomSeemValue = 434334 };
+    //      static int AnotherMagicNumber; // actual value buried in .cpp
 
-	// [naming.bool] Exception from UE4 coding standard:
-	//  DON'T add `b` prefix to bool declaration names!
-	//  instead use English Modal Verbs and variations like: Can, Does, Will, Is, Has, Use, etc
-	bool bInGame, bAttack, bLog, bCustomStencil; /* <- BAD */
-	bool InGame, CanAttack, UseLog, HasCustomStencil; /* <- GOOD */
+    // [naming.bool] Exception from UE4 coding standard:
+    //  DON'T add `b` prefix to bool declaration names!
+    //  instead use English Modal Verbs and variations like: Can, Does, Will, Is, Has, Use, etc
+    bool bInGame, bAttack, bLog, bCustomStencil; /* <- BAD */
+    bool InGame, CanAttack, UseLog, HasCustomStencil; /* <- GOOD */
 };
 
 // [class.inline.good]
@@ -272,7 +271,7 @@ private:
 //      you can easily move this to the .cpp without messing up the class definition
 inline const USkeletalMeshComponent* ASDCodingStandardExampleActor::GoodExampleOfInline() const
 {
-	return OtherMesh.Get();
+    return OtherMesh.Get();
 }
 
 // [cpp.rel_ops] when implementing relation operators, use the binary free form
@@ -280,20 +279,20 @@ inline const USkeletalMeshComponent* ASDCodingStandardExampleActor::GoodExampleO
 //  if it needs to access private members, make it `friend` and respect [class.inline.good]
 //  NOTE: add working functionality only for `==` and `<` everything else can be inferred from them
 inline bool operator == (
-	const USDCodingStandardExampleComponent& lhs,
-	const USDCodingStandardExampleComponent& rhs)
+    const USDCodingStandardExampleComponent& lhs,
+    const USDCodingStandardExampleComponent& rhs)
 {
-	return lhs.InGame == rhs.InGame;
+    return lhs.InGame == rhs.InGame;
 }
 
 // [cpp.namepace.public] Use a namespace to contain free functions.
 //  This helps manage potential name clashes and unity build issues.
 namespace SDCodingStandardHelpers
 {
-	void PublicHelper(const USDCodingStandardExampleComponent& Object);
+    void PublicHelper(const USDCodingStandardExampleComponent& Object);
 }
 
-// [module.naming] when adding new module folders to the code base follow a consistent naming convention
+// [module.naming] when adding new module folders follow a consistent naming convention
 //  - Interface modules should be prefixed with Interface.
 //  - Game independent modules should be prefixed with Core.
 //  - Game specific modules do not have any prefix.

--- a/SplashDamageCodingStandard.h
+++ b/SplashDamageCodingStandard.h
@@ -77,65 +77,65 @@ UCLASS()
 //  - See [module.naming.class]
 class ASDCodingStandardExampleActor : public ACharacter
 {
-    GENERATED_BODY() // GENERATED_UCLASS_BODY is deprecated
+	GENERATED_BODY() // GENERATED_UCLASS_BODY is deprecated
 
-    // [ue.gen.access] follow up the reflection macros with access level specifiers 
-    //  because they don't modify them anymore (used to be the case)
-    //  structs do not need to specify public, unless they also specify protected/private (see [ue.gen.struct])
+	// [ue.gen.access] follow up the reflection macros with access level specifiers 
+	//  because they don't modify them anymore (used to be the case)
+	//  structs do not need to specify public, unless they also specify protected/private (see [ue.gen.struct])
 public:
 
-    // [class.ctor.default] don't write an empty one, remove it
-    //  due to the way GENERATED_BODY works, `= default`-ing the constructor can lead to crashes
+	// [class.ctor.default] don't write an empty one, remove it
+	//  due to the way GENERATED_BODY works, `= default`-ing the constructor can lead to crashes
 
-    // [class.dtor] don't write empty one, default or remove it
-    //  respect the rule of 3/5/0 http://en.cppreference.com/w/cpp/language/rule_of_three
-    ~ASDCodingStandardExampleActor() = default; // or just remove
+	// [class.dtor] don't write empty one, default or remove it
+	//  respect the rule of 3/5/0 http://en.cppreference.com/w/cpp/language/rule_of_three
+	~ASDCodingStandardExampleActor() = default; // or just remove
 
-    // [class.virtual] explicitly mark up virtual methods
-    //  - always use the `override` specifier
-    //  - use the `final` specifier with care as it can have large ramifications on downstream classes.
-    //  - group overridden functions by the class that first defined, them using begin/end comments
-    // Begin AActor override
-    virtual void BeginPlay() override;
-    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
-    // End AActor override
+	// [class.virtual] explicitly mark up virtual methods
+	//  - always use the `override` specifier
+	//  - use the `final` specifier with care as it can have large ramifications on downstream classes.
+	//  - group overridden functions by the class that first defined, them using begin/end comments
+	// Begin AActor override
+	virtual void BeginPlay() override;
+	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+	// End AActor override
 
-    // [class.same-line] DON'T write definitions on the same line as declarations!
-    //  it makes debugging impossible
-    // [class.inline.bad] NEVER USE `inline or `FORCEINLINE` inside a class declaration
-    //  - it's useless and leads to linking errors
-    //  - definitions(bodies) inside a class/struct are implicitly inline!
-    // [comment.useless] DON'T write meaningless comments!
-    //  they should always reflect bigger purpose or reveal hidden details
-    // Returns Mesh subobject
-    /* BAD -> */ FORCEINLINE const USkeletalMeshComponent* GetMesh() const { return MyMesh; } /* <- BAD */
+	// [class.same-line] DON'T write definitions on the same line as declarations!
+	//  it makes debugging impossible
+	// [class.inline.bad] NEVER USE `inline or `FORCEINLINE` inside a class declaration
+	//  - it's useless and leads to linking errors
+	//  - definitions(bodies) inside a class/struct are implicitly inline!
+	// [comment.useless] DON'T write meaningless comments!
+	//  they should always reflect bigger purpose or reveal hidden details
+	// Returns Mesh subobject
+	/* BAD -> */ FORCEINLINE const USkeletalMeshComponent* GetMesh() const { return MyMesh; } /* <- BAD */
 
-    // [class.inline.good] Move the definitions of inline function outside the class
-    const USkeletalMeshComponent* GoodExampleOfInline() const;
+	// [class.inline.good] Move the definitions of inline function outside the class
+	const USkeletalMeshComponent* GoodExampleOfInline() const;
 
 protected:
-    // [class.order] Do not alternate between functions and variables in the class declaration
-    //  Put all functions first, all variables last
+	// [class.order] Do not alternate between functions and variables in the class declaration
+	//  Put all functions first, all variables last
 
-    // [ue.ecs.split] Split functionality into components
-    //  avoid creating monolithic giant classes!
+	// [ue.ecs.split] Split functionality into components
+	//  avoid creating monolithic giant classes!
 
-    // [ue.ecs.gc] never use naked pointers to UObject's, always have UPROPERTY or UE smart ptr
-    //  Generally, for storing pointers to classes you don't own, use TWeakObjectPtr.
-    TWeakObjectPtr<const USkeletalMeshComponent> OtherMesh = nullptr;
-    //  Generally, for storing pointers to classes you do own, use UPROPERTY().
-    UPROPERTY(BlueprintReadOnly, Category = Mesh)
-        const USkeletalMeshComponent* MyMesh = nullptr;
-    //  For more information on other forms of UE4 smart pointers see
-    //  https://docs.unrealengine.com/latest/INT/Programming/UnrealArchitecture/SmartPointerLibrary/ 
+	// [ue.ecs.gc] never use naked pointers to UObject's, always have UPROPERTY or UE smart ptr
+	//  Generally, for storing pointers to classes you don't own, use TWeakObjectPtr.
+	TWeakObjectPtr<const USkeletalMeshComponent> OtherMesh = nullptr;
+	//  Generally, for storing pointers to classes you do own, use UPROPERTY().
+	UPROPERTY(BlueprintReadOnly, Category = Mesh)
+		const USkeletalMeshComponent* MyMesh = nullptr;
+	//  For more information on other forms of UE4 smart pointers see
+	//  https://docs.unrealengine.com/latest/INT/Programming/UnrealArchitecture/SmartPointerLibrary/ 
 
-    // [class.order.replication] As an exception to [class.ordering], declare replication functions
-    //  next to the variable that used them to avoid cluttering the interface with these functions 
-    //  that are not called by client code.
-    UPROPERTY(Transient, ReplicatedUsing = "OnRep_WantsToSprint")
-        bool WantsToSprint = false;
-    UFUNCTION()
-        void OnRep_WantsToSprint();
+	// [class.order.replication] As an exception to [class.ordering], declare replication functions
+	//  next to the variable that used them to avoid cluttering the interface with these functions 
+	//  that are not called by client code.
+	UPROPERTY(Transient, ReplicatedUsing = "OnRep_WantsToSprint")
+		bool WantsToSprint = false;
+	UFUNCTION()
+		void OnRep_WantsToSprint();
 };
 
 // [ue.gen.struct] [ue.ecs.group] move groups of Blueprint exposed variables into separate structures
@@ -145,38 +145,38 @@ protected:
 USTRUCT(BlueprintType)
 struct FSDCodingStandardBlueprintVarGroup
 {
-    GENERATED_BODY()
+	GENERATED_BODY()
 
-        // [vs.plugin] some good tools to help manage these special meta attributes
-        //  it's a pain to write them by hand
-        //  - UE4 Intellisense https://marketplace.visualstudio.com/items?itemName=RxCompiLe.UE4Intellisense
-        //  - SpecifierTool https://marketplace.visualstudio.com/items?itemName=patience2012.SpecifierTool
-        UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-        TArray<int> WidgetCameraLevels; // [class.member.def] Unreal arrays start initialized and empty
+		// [vs.plugin] some good tools to help manage these special meta attributes
+		//  it's a pain to write them by hand
+		//  - UE4 Intellisense https://marketplace.visualstudio.com/items?itemName=RxCompiLe.UE4Intellisense
+		//  - SpecifierTool https://marketplace.visualstudio.com/items?itemName=patience2012.SpecifierTool
+		UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
+		TArray<int> WidgetCameraLevels; // [class.member.def] Unreal arrays start initialized and empty
 
-        // [class.member.def] always provide defaults for member variables
-        //  prefer assigning them here, not in the constructor - that should be reserved
-        //  for more complicated init logic / creation 
-    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-        float CameraTraceVolumeWidth = 96.0f * 5;
+		// [class.member.def] always provide defaults for member variables
+		//  prefer assigning them here, not in the constructor - that should be reserved
+		//  for more complicated init logic / creation 
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
+		float CameraTraceVolumeWidth = 96.0f * 5;
 
-    // [class.member.config] member variables that are used as editor config variables
-    //  MUST have a comment supplied as it shows up as the tooltip in the Editor.
-    //  They should also be marked as EditDefaultsOnly by default.
-    //  If you expect them to be read in blueprints then use BlueprintReadOnly.
-    //  Only use EditAnywhere, EditInstanceOnly or BlueprintReadWrite if it's necessary for your use case.
-    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-        float CameraTraceVolumeHeight = 96.0f * 5;
+	// [class.member.config] member variables that are used as editor config variables
+	//  MUST have a comment supplied as it shows up as the tooltip in the Editor.
+	//  They should also be marked as EditDefaultsOnly by default.
+	//  If you expect them to be read in blueprints then use BlueprintReadOnly.
+	//  Only use EditAnywhere, EditInstanceOnly or BlueprintReadWrite if it's necessary for your use case.
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
+		float CameraTraceVolumeHeight = 96.0f * 5;
 
-    // [hardware.cache] try to order data members with cache and alignment in mind
-    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-        bool ShowCameraWidget = true;
+	// [hardware.cache] try to order data members with cache and alignment in mind
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
+		bool ShowCameraWidget = true;
 
-    // [hardware.cache] for ex grouping similar types like this will minimize the 
-    //  internal padding the compiler will add
-    //  general rule of thumb: sort in descending order by size 
-    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
-        bool ShowWeaponWidget = true;
+	// [hardware.cache] for ex grouping similar types like this will minimize the 
+	//  internal padding the compiler will add
+	//  general rule of thumb: sort in descending order by size 
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = Camera)
+		bool ShowWeaponWidget = true;
 };
 
 // [cpp.enum.strong] use the strongly typed enums rather than old C style + dirty namespace tricks
@@ -185,79 +185,79 @@ struct FSDCodingStandardBlueprintVarGroup
 //UENUM(GenerateStringFuncs)
 enum class ESDCodingStandardEnum // `: uint8` optional underlying type 
 {
-    ValueA,
-    ValueB,
-    ValueC,
+	ValueA,
+	ValueB,
+	ValueC,
 
-    // [cpp.enum.generated.count] Don't put a label to represent the number of values in the enum
-    //  use EnumAutoGen::GetNumValues<ESDCodingStandardEnum>() instead.
-    Max // <- BAD
+	// [cpp.enum.generated.count] Don't put a label to represent the number of values in the enum
+	//  use EnumAutoGen::GetNumValues<ESDCodingStandardEnum>() instead.
+	Max // <- BAD
 };
 
 UCLASS()
 class USDCodingStandardExampleComponent : public USceneComponent
 {
-    GENERATED_BODY()
+	GENERATED_BODY()
 
 public:
-    // [func.arg.readability] avoid `bool` function arguments, especially successions of them	
-    /* BAD -> */ void FuncHardToReadOnCall(int Order, bool bSetCache, bool bUseLog) const; /* <- BAD */
-    using TOrder = int;
-    enum class ECacheFlags { Use, Disabled, Unspecified };
-    enum class ELogging { Yes, No };
-    /* GOOD -> */ void FuncNiceToReadOnCall(TOrder, ECacheFlags, ELogging) const;
-    //  argument names in declarations are ignored, try to encode as much meaning as possible in the
-    //  type also even this simple typedef/using goes a long way readability wise at the call site:
-    //  ex: FuncNiceToReadOnCall(FOrder(42), FCacheFlags::Use, FLogFlags::Custom, FLoadOnPlay(false));
+	// [func.arg.readability] avoid `bool` function arguments, especially successions of them	
+	/* BAD -> */ void FuncHardToReadOnCall(int Order, bool bSetCache, bool bUseLog) const; /* <- BAD */
+	using TOrder = int;
+	enum class ECacheFlags { Use, Disabled, Unspecified };
+	enum class ELogging { Yes, No };
+	/* GOOD -> */ void FuncNiceToReadOnCall(TOrder, ECacheFlags, ELogging) const;
+	//  argument names in declarations are ignored, try to encode as much meaning as possible in the
+	//  type also even this simple typedef/using goes a long way readability wise at the call site:
+	//  ex: FuncNiceToReadOnCall(FOrder(42), FCacheFlags::Use, FLogFlags::Custom, FLoadOnPlay(false));
 
-    // [func.arg.readability] avoid consecutive chains of same type, avoid too many arguments
-    /* BAD -> */ void FuncWithTooManyArgs(const FVector& Location, const FVector& Origin,
-        const FVector& EndPoint, const FRotator& Rotation, const UPrimitiveComponent& Parent,
-        const AActor& Owner) const; /* <- BAD */
-    //  try to add a helper structure, or possibly split into more functions that are less complex
+	// [func.arg.readability] avoid consecutive chains of same type, avoid too many arguments
+	/* BAD -> */ void FuncWithTooManyArgs(const FVector& Location, const FVector& Origin,
+		const FVector& EndPoint, const FRotator& Rotation, const UPrimitiveComponent& Parent,
+		const AActor& Owner) const; /* <- BAD */
+	//  try to add a helper structure, or possibly split into more functions that are less complex
 
-    // [singleton.no] NEVER USE SINGLETONS!!!
-    //  - they are very problematic in multi-threaded scenarios
-    //  - they interfere/break with Hot Reload and plugins
-    //  - discuss alternatives with your lead
-    //  - if you somehow have to add one, first reconsider
-    //    - then use the Meyers pattern: https://stackoverflow.com/a/1661564
-    /* BAD -> */ static USDCodingStandardExampleComponent* Instance; // defined in .cpp
-    /* VERY BAD -> */ const USDCodingStandardExampleComponent* GetInstance() const { return Instance; }
+	// [singleton.no] NEVER USE SINGLETONS!!!
+	//  - they are very problematic in multi-threaded scenarios
+	//  - they interfere/break with Hot Reload and plugins
+	//  - discuss alternatives with your lead
+	//  - if you somehow have to add one, first reconsider
+	//    - then use the Meyers pattern: https://stackoverflow.com/a/1661564
+	/* BAD -> */ static USDCodingStandardExampleComponent* Instance; // defined in .cpp
+	/* VERY BAD -> */ const USDCodingStandardExampleComponent* GetInstance() const { return Instance; }
 
-    // [ue.alloc] expose the allocation as a policy for new utility methods you write
-    //  this way the caller has a chance to decide how memory is utilized
-    template<class AllocatorType>
-    void GetComponents(TArray<const UActorComponent*, AllocatorType>& OutComponents) const;
+	// [ue.alloc] expose the allocation as a policy for new utility methods you write
+	//  this way the caller has a chance to decide how memory is utilized
+	template<class AllocatorType>
+	void GetComponents(TArray<const UActorComponent*, AllocatorType>& OutComponents) const;
 
-    // [cpp.lambda] used later for guidelines
-    void LambdaStyle(const AActor* ExternalEntity) const;
+	// [cpp.lambda] used later for guidelines
+	void LambdaStyle(const AActor* ExternalEntity) const;
 
-    // [cpp.rel_ops] when implementing relation operators, use the binary free form
-    //  as it provides the most flexibility with operands order and usage
-    //  if it needs to access private members, make it `friend` and respect [class.inline.good]
-    //  NOTE: add working functionality only for `==` and `<` everything else can be inferred
-    friend bool operator == (
-        const USDCodingStandardExampleComponent& lhs,
-        const USDCodingStandardExampleComponent& rhs);
+	// [cpp.rel_ops] when implementing relation operators, use the binary free form
+	//  as it provides the most flexibility with operands order and usage
+	//  if it needs to access private members, make it `friend` and respect [class.inline.good]
+	//  NOTE: add working functionality only for `==` and `<` everything else can be inferred
+	friend bool operator == (
+		const USDCodingStandardExampleComponent& lhs,
+		const USDCodingStandardExampleComponent& rhs);
 
 protected:
-    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
-        FSDCodingStandardBlueprintVarGroup BlueprintGroup;
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+		FSDCodingStandardBlueprintVarGroup BlueprintGroup;
 
 private:
-    // [class.constant] best way to define constants
-    constexpr static int SomeDefaultMagicValue = 0xFF00;
-    //  BAD alternatives:
-    //      #define OtherDefaultMagicValue (5)
-    //      enum { RandomSeemValue = 434334 };
-    //      static int AnotherMagicNumber; // actual value buried in .cpp
+	// [class.constant] best way to define constants
+	constexpr static int SomeDefaultMagicValue = 0xFF00;
+	//  BAD alternatives:
+	//      #define OtherDefaultMagicValue (5)
+	//      enum { RandomSeemValue = 434334 };
+	//      static int AnotherMagicNumber; // actual value buried in .cpp
 
-    // [naming.bool] Exception from UE4 coding standard:
-    //  DON'T add `b` prefix to bool declaration names!
-    //  instead use English Modal Verbs and variations like: Can, Does, Will, Is, Has, Use, etc
-    bool bInGame, bAttack, bLog, bCustomStencil; /* <- BAD */
-    bool InGame, CanAttack, UseLog, HasCustomStencil; /* <- GOOD */
+	// [naming.bool] Exception from UE4 coding standard:
+	//  DON'T add `b` prefix to bool declaration names!
+	//  instead use English Modal Verbs and variations like: Can, Does, Will, Is, Has, Use, etc
+	bool bInGame, bAttack, bLog, bCustomStencil; /* <- BAD */
+	bool InGame, CanAttack, UseLog, HasCustomStencil; /* <- GOOD */
 };
 
 // [class.inline.good]
@@ -271,7 +271,7 @@ private:
 //      you can easily move this to the .cpp without messing up the class definition
 inline const USkeletalMeshComponent* ASDCodingStandardExampleActor::GoodExampleOfInline() const
 {
-    return OtherMesh.Get();
+	return OtherMesh.Get();
 }
 
 // [cpp.rel_ops] when implementing relation operators, use the binary free form
@@ -279,17 +279,17 @@ inline const USkeletalMeshComponent* ASDCodingStandardExampleActor::GoodExampleO
 //  if it needs to access private members, make it `friend` and respect [class.inline.good]
 //  NOTE: add working functionality only for `==` and `<` everything else can be inferred from them
 inline bool operator == (
-    const USDCodingStandardExampleComponent& lhs,
-    const USDCodingStandardExampleComponent& rhs)
+	const USDCodingStandardExampleComponent& lhs,
+	const USDCodingStandardExampleComponent& rhs)
 {
-    return lhs.InGame == rhs.InGame;
+	return lhs.InGame == rhs.InGame;
 }
 
 // [cpp.namepace.public] Use a namespace to contain free functions.
 //  This helps manage potential name clashes and unity build issues.
 namespace SDCodingStandardHelpers
 {
-    void PublicHelper(const USDCodingStandardExampleComponent& Object);
+	void PublicHelper(const USDCodingStandardExampleComponent& Object);
 }
 
 // [module.naming] when adding new module folders follow a consistent naming convention


### PR DESCRIPTION
The standard stated not to initialise TWeakObjPtr as that could cause compile errors, this is incorrect.

Also made the standard more compliant with the column guide.