### PR TITLE
EnsureMsgf can prevent potential errors

### DIFF
--- a/SplashDamageCodingStandard.cpp
+++ b/SplashDamageCodingStandard.cpp
@@ -225,7 +225,7 @@ void EngineChanges()
 	//	 i.e. commenting out the section vs actually removing it
 }
 
-void GameWithEditorChanges(const TArray<int>& Widgets)
+bool GameWithEditorChanges(const TArray<int>& Widgets)
 {
 	// [markup.editor] isolate Editor specific changes in game code
 #if WITH_EDITOR
@@ -233,8 +233,14 @@ void GameWithEditorChanges(const TArray<int>& Widgets)
 
 	// [assert.editor] never assert in Editor code - try to recover to your best effort!
 	check(Widgets.Num()); // <- BAD, will force-crash and potentially destroy work
-	ensureMsgf(Widgets.Num(), TEXT("Must have widgets selected!")); // <- BETTER, doesn't force-crash
+	ensureMsgf(Widgets.Num(), TEXT("Must have widgets selected!")); // <- GOOD, doesn't force-crash
+
+	if (!ensureMsgf(Widgets.Num(), TEXT("Must have widgets selected!"))) // <- BETTER, doesn't force-crash & prevents potential errors
+	{
+		return false;
+	}
 #endif
+	return true;
 }
 
 // [cpp.auto] use `auto` or not at your discretion but BE CONSISTENT

--- a/SplashDamageCodingStandard.cpp
+++ b/SplashDamageCodingStandard.cpp
@@ -235,7 +235,8 @@ bool GameWithEditorChanges(const TArray<int>& Widgets)
 	check(Widgets.Num()); // <- BAD, will force-crash and potentially destroy work
 	ensureMsgf(Widgets.Num(), TEXT("Must have widgets selected!")); // <- GOOD, doesn't force-crash
 
-	if (!ensureMsgf(Widgets.Num(), TEXT("Must have widgets selected!"))) // <- BETTER, doesn't force-crash & prevents potential errors
+	// BETTER, doesn't force-crash & prevents potential errors
+	if (!ensureMsgf(Widgets.Num(), TEXT("Must have widgets selected!")))
 	{
 		return false;
 	}


### PR DESCRIPTION
**EnsureMsgf** can be used to detect errors, but it gives us the opportunity to recover from them as well.

I thought we should have an example of it.
Feel free to modify it or comment any doubt you may have!