### PR TITLE
Fix Blueprints not displaying correctly in the browser

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
 				<div class="row">
 					<div class="column">
 						<h1 id="BP_Standard_02_FunctionsAndMacros" class="accordian-toggle">BP_Standard_02_FunctionsAndMacros</h1>
-						<iframe src="https://blueprintue.com/render/h_8sd3zj" class="embed" scrolling="no" allowfullscreen></iframe>
+						<iframe src="https://blueprintue.com/render/bgm-pryb" class="embed" scrolling="no" allowfullscreen></iframe>
 					</div>
 				</div>
 			</div>
@@ -49,7 +49,7 @@
 				<div class="row">
 					<div class="column">
 						<h1 id="BP_Standard_03_Layout" class="accordian-toggle">BP_Standard_03_Layout</h1>
-						<iframe src="https://blueprintue.com/render/fpfbz87i" class="embed" scrolling="no" allowfullscreen></iframe>
+						<iframe src="https://blueprintue.com/render/ggi07wzj" class="embed" scrolling="no" allowfullscreen></iframe>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
I have temporarily replaced the problematic "Draw Box" nodes with "Print String" nodes, with the string:

> Draw Box node has been temporarily removed from this example due to a rendering bug in blueprintue.com

If/when this rendering bug is addressed, we can revert this change.