### PR TITLE
Changed "Actor" to "Character"

### DIFF
--- a/SplashDamageCodingStandard.cpp
+++ b/SplashDamageCodingStandard.cpp
@@ -314,22 +314,22 @@ void NumericLimits()
 	const int32 MinNegativeIntValue = TNumericLimits<int32>::Min();
 }
 
-void ASDCodingStandardExampleActor::BeginPlay()
+void ASDCodingStandardExampleCharacter::BeginPlay()
 {
 	// [ue.ecs.super] always call Super:: method for Actor/Component tickable overridden functions
 	//  other regular methods don't necessary need to do this
 	Super::BeginPlay();
 }
 
-void ASDCodingStandardExampleActor::GetLifetimeReplicatedProps(
+void ASDCodingStandardExampleCharacter::GetLifetimeReplicatedProps(
 	TArray<FLifetimeProperty>& OutLifetimeProps) const
 {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
-	DOREPLIFETIME(ASDCodingStandardExampleActor, WantsToSprint);
+	DOREPLIFETIME(ASDCodingStandardExampleCharacter, WantsToSprint);
 }
 
-void ASDCodingStandardExampleActor::OnRep_WantsToSprint()
+void ASDCodingStandardExampleCharacter::OnRep_WantsToSprint()
 {
 }
 

--- a/SplashDamageCodingStandard.h
+++ b/SplashDamageCodingStandard.h
@@ -79,7 +79,7 @@ class USkeletalMeshComponent;
 UCLASS()
 // [class.name] embed the agreed project codename while following UE4 naming rules. 
 //  - See [module.naming.class]
-class ASDCodingStandardExampleActor : public ACharacter
+class ASDCodingStandardExampleCharacter : public ACharacter
 {
 	GENERATED_BODY() // GENERATED_UCLASS_BODY is deprecated
 
@@ -93,7 +93,7 @@ public:
 
 	// [class.dtor] don't write empty one, default or remove it
 	//  respect the rule of 3/5/0 http://en.cppreference.com/w/cpp/language/rule_of_three
-	~ASDCodingStandardExampleActor() = default; // or just remove
+	~ASDCodingStandardExampleCharacter() = default; // or just remove
 
 	// [class.virtual] explicitly mark up virtual methods
 	//  - always use the `override` specifier
@@ -270,7 +270,7 @@ private:
 //      this simple function would have been inlined anyway
 //  - having it like this also helps refactoring
 //      you can easily move this to the .cpp without messing up the class definition
-inline const USkeletalMeshComponent* ASDCodingStandardExampleActor::GoodExampleOfInline() const
+inline const USkeletalMeshComponent* ASDCodingStandardExampleCharacter::GoodExampleOfInline() const
 {
 	return OtherMesh.Get();
 }


### PR DESCRIPTION
Renamed ASDCodingStandardExampleActor to ASDCodingStandardExampleCharacter because it is a subclass of ACharacter.

Could also just change it to be a subclass of AActor.